### PR TITLE
Fix Header of BookFile Table Alignment

### DIFF
--- a/frontend/src/Store/Actions/bookFileActions.js
+++ b/frontend/src/Store/Actions/bookFileActions.js
@@ -45,7 +45,7 @@ export const defaultState = {
       name: 'select',
       columnLabel: 'Select',
       isSortable: false,
-      isVisible: true,
+      isVisible: false,
       isModifiable: false,
       isHidden: true
     },


### PR DESCRIPTION
The headers on the BookFile table were not aligned properly.

The fix was pretty easy once I'd tracked down where the columns were defined - in src/Store/Actions/bookFileActions.js, in the columns array, if you update the first object (Select) by changing the isVisible flag to false, the select remains and the headings align properly.
