### PR TITLE
Check for null existing series

### DIFF
--- a/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
@@ -141,8 +141,10 @@ namespace NzbDrone.Core.Books
 
             foreach (var s in remoteData.Series.Value)
             {
-                s.LinkItems.Value.ForEach(x => x.Series = s);
-                links.AddRange(s.LinkItems.Value.Where(x => bookDict.ContainsKey(x.Book.Value.ForeignBookId)));
+                s?.LinkItems?.Value.ForEach(x => x.Series = s);
+                var booksToAdd = s?.LinkItems?.Value
+                    .Where(x => bookDict.ContainsKey(x.Book.Value.ForeignBookId)) ?? new List<SeriesBookLink>();
+                links.AddRange(booksToAdd);
             }
 
             var grouped = links.GroupBy(x => x.Series.Value);


### PR DESCRIPTION
Brandon Sanderson is showing with 0 series in the UI. When I refresh the author I get this error:
```
2026-01-17 10:34:44.4|Error|RefreshAuthorService|Couldn't refresh info for [204214][Brandon Sanderson]

[v0.4.20.107] System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.Books.RefreshSeriesService.RefreshSeriesInfo(Int32 authorMetadataId, List`1 remoteSeries, Author remoteData, Boolean forceBookRefresh, Boolean forceUpdateFileTags, Nullable`1 lastUpdate) in ./Readarr.Core/Books/Services/RefreshSeriesService.cs:line 144
   at NzbDrone.Core.Books.RefreshAuthorService.PublishRefreshCompleteEvent(Author entity) in ./Readarr.Core/Books/Services/RefreshAuthorService.cs:line 298
   at NzbDrone.Core.Books.RefreshEntityServiceBase`2.RefreshEntityInfo(TEntity local, List`1 remoteItems, Author remoteData, Boolean forceChildRefresh, Boolean forceUpdateFileTags, Nullable`1 lastUpdate) in ./Readarr.Core/Books/Services/RefreshEntityServiceBase.cs:line 197
   at NzbDrone.Core.Books.RefreshAuthorService.RefreshSelectedAuthors(List`1 authorIds, Boolean isNew, CommandTrigger trigger) in ./Readarr.Core/Books/Services/RefreshAuthorService.cs:line 356
```

