### PR TITLE
Add Hardcover reading status import support

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImport.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.ImportLists.Hardcover
         public override int PageSize => 200;
 
         public override ProviderMessage Message => new ProviderMessage(
-            "Books from your Hardcover lists will be matched by title and author name against your configured metadata source.",
+            "Books from your Hardcover lists and reading statuses will be matched by title and author name against your configured metadata source.",
             ProviderMessageType.Info);
 
         public HardcoverImport(IHttpClient httpClient,
@@ -62,11 +62,11 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                 }
 
                 var options = _hardcoverProxy.GetLists(Settings)
-                    .OrderBy(l => l.DisplayName, StringComparer.InvariantCultureIgnoreCase)
                     .Select(l => new
                     {
                         Value = l.Id ?? l.Slug ?? l.Name,
-                        Name = l.DisplayName
+                        Name = l.DisplayName,
+                        Hint = l.Hint
                     });
 
                 return new { options };
@@ -80,11 +80,11 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                     Settings.Validate().Filter("BaseUrl", "ApiKey").ThrowOnError();
 
                     var options = _hardcoverProxy.GetLists(Settings)
-                        .OrderBy(l => l.DisplayName, StringComparer.InvariantCultureIgnoreCase)
                         .Select(l => new
                         {
                             Value = l.Id ?? l.Slug ?? l.Name,
-                            Name = l.DisplayName
+                            Name = l.DisplayName,
+                            Hint = l.Hint
                         });
 
                     _logger.Info("Hardcover authentication succeeded for {0}", Settings.BaseUrl);

--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportParser.cs
@@ -59,6 +59,7 @@ namespace NzbDrone.Core.ImportLists.Hardcover
             }
 
             // GraphQL shape: data.me[].lists[].list_books[].book
+            // or:            data.me[].user_books[].book (reading statuses)
             var me = root["data"]?["me"];
             if (me != null && me.Type == JTokenType.Array)
             {
@@ -81,6 +82,19 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                                         books.Add(book);
                                     }
                                 }
+                            }
+                        }
+                    }
+
+                    var userBooks = meItem["user_books"];
+                    if (userBooks != null && userBooks.Type == JTokenType.Array)
+                    {
+                        foreach (var userBook in userBooks.Children())
+                        {
+                            var book = userBook["book"];
+                            if (book != null)
+                            {
+                                books.Add(book);
                             }
                         }
                     }

--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportRequestGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using NLog;
 using NzbDrone.Common.Http;
@@ -7,6 +8,8 @@ namespace NzbDrone.Core.ImportLists.Hardcover
 {
     public class HardcoverImportRequestGenerator : IImportListRequestGenerator
     {
+        private const string StatusPrefix = "status:";
+
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         public HardcoverImportSettings Settings { get; set; }
@@ -18,18 +21,43 @@ namespace NzbDrone.Core.ImportLists.Hardcover
         {
             var pageableRequests = new ImportListPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests());
+            var slugs = new List<string>();
+            var statusIds = new List<int>();
+
+            foreach (var id in Settings.ListIds)
+            {
+                if (id.StartsWith(StatusPrefix))
+                {
+                    if (int.TryParse(id.Substring(StatusPrefix.Length), out var statusId))
+                    {
+                        statusIds.Add(statusId);
+                    }
+                }
+                else
+                {
+                    slugs.Add(id);
+                }
+            }
+
+            if (slugs.Any())
+            {
+                pageableRequests.Add(GetSlugRequests(slugs));
+            }
+
+            if (statusIds.Any())
+            {
+                pageableRequests.Add(GetStatusRequests(statusIds));
+            }
 
             return pageableRequests;
         }
 
-        private IEnumerable<ImportListRequest> GetPagedRequests()
+        private IEnumerable<ImportListRequest> GetSlugRequests(List<string> slugs)
         {
             var apiKey = NormalizeApiKey(Settings.ApiKey);
 
-            Logger.Info("Hardcover: Fetching books for lists '{0}'", Settings.ListIds);
+            Logger.Info("Hardcover: Fetching books for lists '{0}'", string.Join(", ", slugs));
 
-            // Query to fetch selected lists with their books and author info
             var graphQlBody = JsonSerializer.Serialize(new
             {
                 query = @"
@@ -37,10 +65,35 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                 ",
                 variables = new
                 {
-                    slugs = Settings.ListIds
+                    slugs
                 }
             });
 
+            yield return new ImportListRequest(BuildRequest(apiKey, graphQlBody));
+        }
+
+        private IEnumerable<ImportListRequest> GetStatusRequests(List<int> statusIds)
+        {
+            var apiKey = NormalizeApiKey(Settings.ApiKey);
+
+            Logger.Info("Hardcover: Fetching books for reading statuses '{0}'", string.Join(", ", statusIds));
+
+            var graphQlBody = JsonSerializer.Serialize(new
+            {
+                query = @"
+                    query UserBooks($statusIds: [Int!]!) { me { user_books(where: { status_id: { _in: $statusIds } }) { book { id title contributions { author { id name } } } } } }
+                ",
+                variables = new
+                {
+                    statusIds
+                }
+            });
+
+            yield return new ImportListRequest(BuildRequest(apiKey, graphQlBody));
+        }
+
+        private HttpRequest BuildRequest(string apiKey, string graphQlBody)
+        {
             var request = new HttpRequestBuilder($"{Settings.BaseUrl.TrimEnd('/')}/v1/graphql")
                 .Post()
                 .Accept(HttpAccept.Json)
@@ -52,8 +105,7 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                 .Build();
 
             request.SetContent(graphQlBody);
-
-            yield return new ImportListRequest(request);
+            return request;
         }
 
         private string NormalizeApiKey(string apiKey)

--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverImportSettings.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.ImportLists.Hardcover
         [FieldDefinition(1, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Hardcover personal API key (from Settings > API)")]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(2, Type = FieldType.Select, SelectOptionsProviderAction = "getLists", Label = "List", HelpText = "Choose a list from your Hardcover account to sync")]
+        [FieldDefinition(2, Type = FieldType.Select, SelectOptionsProviderAction = "getLists", Label = "Lists", HelpText = "Choose lists or reading statuses from your Hardcover account to sync")]
         public IEnumerable<string> ListIds { get; set; }
 
         public string ListId => ListIds?.FirstOrDefault();

--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
@@ -72,7 +72,9 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                 new HardcoverListResource { Id = "status:1", Name = "Want to Read", Hint = "Reading Status" },
                 new HardcoverListResource { Id = "status:2", Name = "Currently Reading", Hint = "Reading Status" },
                 new HardcoverListResource { Id = "status:3", Name = "Read", Hint = "Reading Status" },
+                new HardcoverListResource { Id = "status:4", Name = "Paused", Hint = "Reading Status" },
                 new HardcoverListResource { Id = "status:5", Name = "Did Not Finish", Hint = "Reading Status" },
+                new HardcoverListResource { Id = "status:6", Name = "Ignored", Hint = "Reading Status" },
             };
         }
 

--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
@@ -50,11 +50,30 @@ namespace NzbDrone.Core.ImportLists.Hardcover
             }
 
             var payload = JsonConvert.DeserializeObject<HardcoverGraphQlResponse>(response.Content);
-            var lists = payload?.GetLists() ?? new List<HardcoverListResource>();
+            var customLists = payload?.GetLists() ?? new List<HardcoverListResource>();
 
-            _logger.Debug("Hardcover: Found {0} lists", lists.Count);
+            foreach (var list in customLists)
+            {
+                list.Hint = "Custom List";
+            }
 
-            return lists;
+            _logger.Debug("Hardcover: Found {0} custom lists", customLists.Count);
+
+            var allOptions = GetReadingStatusOptions();
+            allOptions.AddRange(customLists);
+
+            return allOptions;
+        }
+
+        private static List<HardcoverListResource> GetReadingStatusOptions()
+        {
+            return new List<HardcoverListResource>
+            {
+                new HardcoverListResource { Id = "status:1", Name = "Want to Read", Hint = "Reading Status" },
+                new HardcoverListResource { Id = "status:2", Name = "Currently Reading", Hint = "Reading Status" },
+                new HardcoverListResource { Id = "status:3", Name = "Read", Hint = "Reading Status" },
+                new HardcoverListResource { Id = "status:5", Name = "Did Not Finish", Hint = "Reading Status" },
+            };
         }
 
         public ValidationFailure Test(HardcoverImportSettings settings)
@@ -151,6 +170,9 @@ namespace NzbDrone.Core.ImportLists.Hardcover
 
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonIgnore]
+        public string Hint { get; set; }
 
         public string DisplayName => Name ?? Slug ?? Id;
     }


### PR DESCRIPTION
# PR: Add Hardcover reading status import support

<img width="818" height="450" alt="CleanShot 2026-03-01 at 22 29 51@2x" src="https://github.com/user-attachments/assets/5b055121-329d-4148-9859-36ca768c5657" />

Solves https://github.com/pennydreadful/bookshelf/issues/115


**Target:** `pennydreadful/bookshelf` `develop` branch

## Summary

Extends the Hardcover import list to support importing books by **reading status** (Want to Read, Currently Reading, Read, Paused, Did Not Finish, Ignored) in addition to the existing custom list import.

## Changes

- **HardcoverImportRequestGenerator.cs** - Added `GetStatusRequests()` to generate GraphQL queries for `user_books` filtered by `status_id`, alongside the existing `GetSlugRequests()` for custom lists. List IDs prefixed with `status:` are routed to the status query path.
- **HardcoverImportParser.cs** - Extended `GetItemsToken()` to handle the `data.me[].user_books[].book` response shape returned by reading status queries.
- **HardcoverProxy.cs** - Added all six Hardcover reading statuses as selectable options in the import list dropdown (Want to Read, Currently Reading, Read, Paused, Did Not Finish, Ignored).
- **HardcoverImportSettings.cs** - Updated help text to reflect that both lists and reading statuses are supported.
- **HardcoverImport.cs** - Minor adjustments to support the combined list/status flow.

## How it works

The `ListIds` setting now accepts both custom list slugs (e.g., `"owned"`) and status identifiers (e.g., `"status:1"`). The request generator separates these into two groups:

1. **Custom lists** - Queried via `me { lists(where: { slug: { _in: $slugs } }) { ... } }`
2. **Reading statuses** - Queried via `me { user_books(where: { status_id: { _in: $statusIds } }) { ... } }`

Both query types return the same book structure (`id`, `title`, `contributions[].author{id, name}`) and are parsed identically.

### Hardcover Reading Status IDs

| ID | Status |
|----|--------|
| 1  | Want to Read |
| 2  | Currently Reading |
| 3  | Read |
| 4  | Paused |
| 5  | Did Not Finish |
| 6  | Ignored |

## Testing

Tested with a live Hardcover account against the production API:
- Authenticated successfully with Hardcover API
- "Want to Read" (status:1) returned 181 books
- All 181 books were parsed and processed correctly (143 unique authors, 181 books added)
- Custom list import continues to work alongside status import
- Mixed selections (both lists and statuses) are supported

## Test plan

- [ ] Configure a Hardcover import list and select one or more reading statuses
- [ ] Trigger an import list sync and verify books are imported
- [ ] Verify custom list import still works when selected alongside statuses
- [ ] Verify the "Test" button on the import list settings works
- [ ] Verify the list dropdown shows all six reading statuses plus any custom lists
