### PR TITLE
persist credits; new audio tags; sanitize tags; docker dev

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,65 @@
+# Multi-stage Dockerfile for local builds without host tooling
+# Usage: docker build -f docker/Dockerfile.dev -t bookshelf:dev .
+#
+# Non-hardcover (softcover) build by default.
+# For hardcover: docker build -f docker/Dockerfile.dev -t bookshelf:hardcover --build-arg METADATA_URL=https://hardcover.bookinfo.pro --build-arg HARDCOVER=true .
+
+# ── Stage 1: Build backend ──────────────────────────────────────────────
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS backend
+
+WORKDIR /build
+COPY .editorconfig ./
+COPY Logo/ Logo/
+COPY src/ src/
+RUN dotnet msbuild -restore src/Readarr.sln \
+    -p:Configuration=Release \
+    -p:Platform=Posix \
+    -p:RuntimeIdentifiers=linux-musl-x64 \
+    -t:PublishAllRids
+
+# ── Stage 2: Build frontend ─────────────────────────────────────────────
+FROM node:20-alpine AS frontend
+
+WORKDIR /build
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --network-timeout 120000
+
+COPY frontend/ frontend/
+COPY tsconfig.json ./
+RUN yarn run build --env production
+
+# ── Stage 3: Final image ────────────────────────────────────────────────
+FROM ghcr.io/linuxserver/baseimage-alpine:3.21
+
+ENV XDG_CONFIG_HOME="/config/xdg" \
+    COMPlus_EnableDiagnostics=0 \
+    TMPDIR=/run/readarr-temp
+
+RUN apk add -U --upgrade --no-cache \
+    icu-libs \
+    sqlite-libs \
+    xmlstarlet
+
+ARG GIT_BRANCH=develop
+ARG COMMIT_HASH=dev
+ARG BUILD_DATE=unknown
+ARG METADATA_URL=https://api.bookinfo.pro
+ARG HARDCOVER
+
+LABEL maintainer="pennydreadful"
+
+ENV METADATA_URL=${METADATA_URL}
+ENV HARDCOVER=${HARDCOVER}
+
+RUN mkdir -p /app/readarr/bin
+
+COPY --from=backend /build/_output/net6.0/linux-musl-x64/publish/ /app/readarr/bin/
+COPY --from=frontend /build/_output/UI/ /app/readarr/bin/UI/
+
+RUN echo -e "UpdateMethod=docker\nBranch=${GIT_BRANCH}\nPackageVersion=${COMMIT_HASH}\nPackageAuthor=pennydreadful" > /app/readarr/package_info && \
+    printf "version: ${COMMIT_HASH}\nBuild-date: ${BUILD_DATE}" > /build_version
+
+COPY docker/root/ /
+
+EXPOSE 8787
+VOLUME /config

--- a/src/NzbDrone.Core.Test/MediaFiles/ChplAtomRepairFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ChplAtomRepairFixture.cs
@@ -1,0 +1,201 @@
+using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MediaFiles
+{
+    [TestFixture]
+    public class ChplAtomRepairFixture : CoreTest
+    {
+        private string _tempFile;
+
+        [TearDown]
+        public void Cleanup()
+        {
+            if (_tempFile != null && File.Exists(_tempFile))
+            {
+                File.Delete(_tempFile);
+            }
+        }
+
+        /// <summary>
+        /// Builds a minimal MPEG-4 file structure in memory.
+        /// Layout: ftyp + moov(udta(chpl(...)))
+        /// </summary>
+        private byte[] BuildMp4WithChpl(byte chplVersion, byte[] chplPayload)
+        {
+            // chpl atom: size(4) + "chpl"(4) + version(1) + flags(3) + [reserved(1) if v1] + payload
+            var chplHeaderLen = 4 + 4 + 1 + 3 + (chplVersion == 1 ? 1 : 0);
+            var chplSize = chplHeaderLen + chplPayload.Length;
+
+            // udta atom: size(4) + "udta"(4) + chpl
+            var udtaSize = 8 + chplSize;
+
+            // moov atom: size(4) + "moov"(4) + udta
+            var moovSize = 8 + udtaSize;
+
+            // ftyp atom: size(4) + "ftyp"(4) + "M4B "(4) = 12
+            var ftypSize = 12;
+
+            var total = ftypSize + moovSize;
+            var ms = new MemoryStream(total);
+            var bw = new BinaryWriter(ms);
+
+            // ftyp
+            WriteBigEndianInt32(bw, ftypSize);
+            bw.Write(Encoding.ASCII.GetBytes("ftyp"));
+            bw.Write(Encoding.ASCII.GetBytes("M4B "));
+
+            // moov
+            WriteBigEndianInt32(bw, moovSize);
+            bw.Write(Encoding.ASCII.GetBytes("moov"));
+
+            // udta
+            WriteBigEndianInt32(bw, udtaSize);
+            bw.Write(Encoding.ASCII.GetBytes("udta"));
+
+            // chpl
+            WriteBigEndianInt32(bw, chplSize);
+            bw.Write(Encoding.ASCII.GetBytes("chpl"));
+            bw.Write(chplVersion);           // version
+            bw.Write(new byte[] { 0, 0, 0 }); // flags
+            if (chplVersion == 1)
+            {
+                bw.Write((byte)0x00);          // reserved byte
+            }
+
+            bw.Write(chplPayload);
+
+            return ms.ToArray();
+        }
+
+        private static void WriteBigEndianInt32(BinaryWriter writer, int value)
+        {
+            writer.Write((byte)((value >> 24) & 0xFF));
+            writer.Write((byte)((value >> 16) & 0xFF));
+            writer.Write((byte)((value >> 8) & 0xFF));
+            writer.Write((byte)(value & 0xFF));
+        }
+
+        private string WriteTempFile(byte[] data)
+        {
+            _tempFile = Path.Combine(Path.GetTempPath(), $"chpltest_{Guid.NewGuid()}.m4b");
+            File.WriteAllBytes(_tempFile, data);
+            return _tempFile;
+        }
+
+        [Test]
+        public void FindNestedAtom_should_locate_chpl_inside_moov_udta()
+        {
+            var chplPayload = new byte[] { 0x00, 0x00, 0x00, 0x01 }; // 1 chapter
+            var data = BuildMp4WithChpl(0x01, chplPayload);
+
+            using (var ms = new MemoryStream(data))
+            {
+                var offset = AudioTag.FindNestedAtom(ms, 0, ms.Length, "moov", "udta", "chpl");
+                offset.Should().BeGreaterOrEqualTo(0);
+
+                // Verify the atom type at the found offset
+                ms.Seek(offset + 4, SeekOrigin.Begin);
+                var typeBytes = new byte[4];
+                ms.Read(typeBytes, 0, 4);
+                Encoding.ASCII.GetString(typeBytes).Should().Be("chpl");
+            }
+        }
+
+        [Test]
+        public void FindNestedAtom_should_return_negative_for_missing_atom()
+        {
+            var chplPayload = new byte[] { 0x00, 0x00, 0x00, 0x01 };
+            var data = BuildMp4WithChpl(0x01, chplPayload);
+
+            using (var ms = new MemoryStream(data))
+            {
+                var offset = AudioTag.FindNestedAtom(ms, 0, ms.Length, "moov", "udta", "hdlr");
+                offset.Should().Be(-1);
+            }
+        }
+
+        [Test]
+        public void RepairChplAtom_should_neutralize_version_0_chpl()
+        {
+            // Simulate what TagLib writes: version 0 chpl (corrupted from version 1)
+            var chplPayload = new byte[] { 0x00, 0x00, 0x00, 0x02 }; // 2 chapters
+            var data = BuildMp4WithChpl(0x00, chplPayload);
+            var path = WriteTempFile(data);
+
+            AudioTag.RepairChplAtom(path);
+
+            // Read back and verify "chpl" was replaced with "free"
+            var repaired = File.ReadAllBytes(path);
+            using (var ms = new MemoryStream(repaired))
+            {
+                // chpl was inside moov/udta, find udta contents start
+                var chplOffset = AudioTag.FindNestedAtom(ms, 0, ms.Length, "moov", "udta", "chpl");
+                chplOffset.Should().Be(-1, "chpl should no longer exist");
+
+                var freeOffset = AudioTag.FindNestedAtom(ms, 0, ms.Length, "moov", "udta", "free");
+                freeOffset.Should().BeGreaterOrEqualTo(0, "free atom should exist in place of chpl");
+            }
+        }
+
+        [Test]
+        public void RepairChplAtom_should_not_touch_version_1_chpl()
+        {
+            // Version 1 chpl is valid and should not be modified
+            var chplPayload = new byte[] { 0x00, 0x00, 0x00, 0x02 }; // 2 chapters
+            var data = BuildMp4WithChpl(0x01, chplPayload);
+            var path = WriteTempFile(data);
+
+            var originalBytes = File.ReadAllBytes(path);
+
+            AudioTag.RepairChplAtom(path);
+
+            var afterRepair = File.ReadAllBytes(path);
+            afterRepair.Should().BeEquivalentTo(originalBytes, "version 1 chpl should be left unchanged");
+        }
+
+        [Test]
+        public void RepairChplAtom_should_handle_file_without_chpl()
+        {
+            // Minimal MP4 with just ftyp + moov(udta()) but no chpl
+            var ms = new MemoryStream();
+            var bw = new BinaryWriter(ms);
+
+            // ftyp
+            WriteBigEndianInt32(bw, 12);
+            bw.Write(Encoding.ASCII.GetBytes("ftyp"));
+            bw.Write(Encoding.ASCII.GetBytes("M4B "));
+
+            // moov with empty udta
+            var udtaSize = 8;
+            var moovSize = 8 + udtaSize;
+            WriteBigEndianInt32(bw, moovSize);
+            bw.Write(Encoding.ASCII.GetBytes("moov"));
+            WriteBigEndianInt32(bw, udtaSize);
+            bw.Write(Encoding.ASCII.GetBytes("udta"));
+
+            var data = ms.ToArray();
+            var path = WriteTempFile(data);
+
+            var originalBytes = File.ReadAllBytes(path);
+
+            // Should not throw and file should be unchanged
+            AudioTag.RepairChplAtom(path);
+
+            var afterRepair = File.ReadAllBytes(path);
+            afterRepair.Should().BeEquivalentTo(originalBytes);
+        }
+
+        [Test]
+        public void RepairChplAtom_should_handle_missing_file()
+        {
+            // Should not throw for a non-existent file
+            AudioTag.RepairChplAtom(Path.Combine(Path.GetTempPath(), "nonexistent_file.m4b"));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/Model/Credit.cs
+++ b/src/NzbDrone.Core/Books/Model/Credit.cs
@@ -1,0 +1,11 @@
+using Equ;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Books
+{
+    public class Credit : MemberwiseEquatable<Credit>, IEmbeddedDocument
+    {
+        public string Name { get; set; }
+        public string Role { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Books/Model/Edition.cs
+++ b/src/NzbDrone.Core/Books/Model/Edition.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Books
             Images = new List<MediaCover.MediaCover>();
             Links = new List<Links>();
             Ratings = new Ratings();
+            Credits = new List<Credit>();
         }
 
         // These correspond to columns in the Books table
@@ -37,6 +38,7 @@ namespace NzbDrone.Core.Books
         public List<MediaCover.MediaCover> Images { get; set; }
         public List<Links> Links { get; set; }
         public Ratings Ratings { get; set; }
+        public List<Credit> Credits { get; set; }
 
         // These are Readarr generated/config
         public bool Monitored { get; set; }
@@ -71,6 +73,7 @@ namespace NzbDrone.Core.Books
             Images = other.Images.Any() ? other.Images : Images;
             Links = other.Links;
             Ratings = other.Ratings;
+            Credits = other.Credits;
         }
 
         public override void UseDbFieldsFrom(Edition other)

--- a/src/NzbDrone.Core/Datastore/Migration/041_add_credits_to_editions.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/041_add_credits_to_editions.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(041)]
+    public class add_credits_to_editions : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Editions").AddColumn("Credits").AsString().Nullable().WithDefaultValue("[]");
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/AudioTag.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTag.cs
@@ -33,6 +33,8 @@ namespace NzbDrone.Core.MediaFiles
         public string Publisher { get; set; }
         public TimeSpan Duration { get; set; }
         public string[] Genres { get; set; }
+        public string Narrator { get; set; }
+        public string Illustrator { get; set; }
         public string ImageFile { get; set; }
         public long ImageSize { get; set; }
 
@@ -105,6 +107,11 @@ namespace NzbDrone.Core.MediaFiles
                     Media = id3tag.GetTextAsString("TMED");
                     Date = ReadId3Date(id3tag, "TDRC");
                     OriginalReleaseDate = ReadId3Date(id3tag, "TDOR");
+
+                    var narratorFrame = UserTextInformationFrame.Get(id3tag, "NARRATOR", false);
+                    Narrator = narratorFrame?.Text?.FirstOrDefault();
+                    var illustratorFrame = UserTextInformationFrame.Get(id3tag, "ILLUSTRATOR", false);
+                    Illustrator = illustratorFrame?.Text?.FirstOrDefault();
                 }
                 else if (file.TagTypesOnDisk.HasFlag(TagTypes.Xiph))
                 {
@@ -115,6 +122,8 @@ namespace NzbDrone.Core.MediaFiles
                     Date = DateTime.TryParse(flactag.GetField("DATE").ExclusiveOrDefault(), out tempDate) ? tempDate : default(DateTime?);
                     OriginalReleaseDate = DateTime.TryParse(flactag.GetField("ORIGINALDATE").ExclusiveOrDefault(), out tempDate) ? tempDate : default(DateTime?);
                     Publisher = flactag.GetField("LABEL").ExclusiveOrDefault();
+                    Narrator = flactag.GetField("NARRATOR").ExclusiveOrDefault();
+                    Illustrator = flactag.GetField("ILLUSTRATOR").ExclusiveOrDefault();
                 }
                 else if (file.TagTypesOnDisk.HasFlag(TagTypes.Ape))
                 {
@@ -123,6 +132,8 @@ namespace NzbDrone.Core.MediaFiles
                     Date = DateTime.TryParse(apetag.GetItem("Year")?.ToString(), out tempDate) ? tempDate : default(DateTime?);
                     OriginalReleaseDate = DateTime.TryParse(apetag.GetItem("Original Date")?.ToString(), out tempDate) ? tempDate : default(DateTime?);
                     Publisher = apetag.GetItem("Label")?.ToString();
+                    Narrator = apetag.GetItem("Narrator")?.ToString();
+                    Illustrator = apetag.GetItem("Illustrator")?.ToString();
                 }
                 else if (file.TagTypesOnDisk.HasFlag(TagTypes.Asf))
                 {
@@ -131,6 +142,8 @@ namespace NzbDrone.Core.MediaFiles
                     Date = DateTime.TryParse(asftag.GetDescriptorString("WM/Year"), out tempDate) ? tempDate : default(DateTime?);
                     OriginalReleaseDate = DateTime.TryParse(asftag.GetDescriptorString("WM/OriginalReleaseTime"), out tempDate) ? tempDate : default(DateTime?);
                     Publisher = asftag.GetDescriptorString("WM/Publisher");
+                    Narrator = asftag.GetDescriptorString("WM/Narrator");
+                    Illustrator = asftag.GetDescriptorString("WM/Illustrator");
                 }
                 else if (file.TagTypesOnDisk.HasFlag(TagTypes.Apple))
                 {
@@ -138,6 +151,8 @@ namespace NzbDrone.Core.MediaFiles
                     Media = appletag.GetDashBox("com.apple.iTunes", "MEDIA");
                     Date = DateTime.TryParse(appletag.DataBoxes(FixAppleId("day")).FirstOrDefault()?.Text, out tempDate) ? tempDate : default(DateTime?);
                     OriginalReleaseDate = DateTime.TryParse(appletag.GetDashBox("com.apple.iTunes", "Original Date"), out tempDate) ? tempDate : default(DateTime?);
+                    Narrator = appletag.GetDashBox("com.apple.iTunes", "NARRATOR");
+                    Illustrator = appletag.GetDashBox("com.apple.iTunes", "ILLUSTRATOR");
                 }
 
                 OriginalYear = OriginalReleaseDate.HasValue ? (uint)OriginalReleaseDate?.Year : 0;
@@ -298,15 +313,36 @@ namespace NzbDrone.Core.MediaFiles
             return null;
         }
 
+        private static string SanitizeTagValue(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            var sanitized = new string(value.Where(c => c >= ' ' || c == '\t' || c == '\n' || c == '\r').ToArray());
+
+            return sanitized.Length > 0 ? sanitized : null;
+        }
+
+        private static string[] SanitizeTagValues(string[] values)
+        {
+            return values?.Select(SanitizeTagValue).Where(v => v != null).ToArray() ?? new string[0];
+        }
+
         public void Write(string path)
         {
             Logger.Debug($"Starting tag write for {path}");
 
-            // patch up any null fields to work around TagLib exception for
-            // WMA with null performers/bookauthors
-            Performers = Performers ?? new string[0];
-            BookAuthors = BookAuthors ?? new string[0];
-            Genres = Genres ?? new string[0];
+            Title = SanitizeTagValue(Title);
+            Book = SanitizeTagValue(Book);
+            Publisher = SanitizeTagValue(Publisher);
+            Media = SanitizeTagValue(Media);
+            Narrator = SanitizeTagValue(Narrator);
+            Illustrator = SanitizeTagValue(Illustrator);
+            Performers = SanitizeTagValues(Performers);
+            BookAuthors = SanitizeTagValues(BookAuthors);
+            Genres = SanitizeTagValues(Genres);
 
             TagLib.File file = null;
             try
@@ -326,17 +362,14 @@ namespace NzbDrone.Core.MediaFiles
                 tag.Publisher = Publisher;
                 tag.Genres = Genres;
 
-                if (ImageFile.IsNotNullOrWhiteSpace())
-                {
-                    tag.Pictures = new IPicture[1] { new Picture(ImageFile) };
-                }
-
                 if (file.TagTypes.HasFlag(TagTypes.Id3v2))
                 {
                     var id3tag = (TagLib.Id3v2.Tag)file.GetTag(TagTypes.Id3v2);
                     id3tag.SetTextFrame("TMED", Media);
                     WriteId3Date(id3tag, "TDRC", "TYER", "TDAT", Date);
                     WriteId3Date(id3tag, "TDOR", "TORY", null, OriginalReleaseDate);
+                    WriteId3Tag(id3tag, "NARRATOR", Narrator);
+                    WriteId3Tag(id3tag, "ILLUSTRATOR", Illustrator);
                 }
                 else if (file.TagTypes.HasFlag(TagTypes.Xiph))
                 {
@@ -358,6 +391,8 @@ namespace NzbDrone.Core.MediaFiles
                     flactag.SetField("TOTALDISCS", DiscCount);
                     flactag.SetField("MEDIA", Media);
                     flactag.SetField("LABEL", Publisher);
+                    flactag.SetField("NARRATOR", Narrator);
+                    flactag.SetField("ILLUSTRATOR", Illustrator);
                 }
                 else if (file.TagTypes.HasFlag(TagTypes.Ape))
                 {
@@ -368,6 +403,8 @@ namespace NzbDrone.Core.MediaFiles
                     apetag.SetValue("Original Year", OriginalReleaseDate.HasValue ? OriginalReleaseDate.Value.Year.ToString() : null);
                     apetag.SetValue("Media", Media);
                     apetag.SetValue("Label", Publisher);
+                    apetag.SetValue("Narrator", Narrator);
+                    apetag.SetValue("Illustrator", Illustrator);
                 }
                 else if (file.TagTypes.HasFlag(TagTypes.Asf))
                 {
@@ -378,6 +415,8 @@ namespace NzbDrone.Core.MediaFiles
                     asftag.SetDescriptorString(OriginalReleaseDate.HasValue ? OriginalReleaseDate.Value.Year.ToString() : null, "WM/OriginalReleaseYear");
                     asftag.SetDescriptorString(Media, "WM/Media");
                     asftag.SetDescriptorString(Publisher, "WM/Publisher");
+                    asftag.SetDescriptorString(Narrator, "WM/Narrator");
+                    asftag.SetDescriptorString(Illustrator, "WM/Illustrator");
                 }
                 else if (file.TagTypes.HasFlag(TagTypes.Apple))
                 {
@@ -387,6 +426,14 @@ namespace NzbDrone.Core.MediaFiles
                     appletag.SetDashBox("com.apple.iTunes", "Original Date", OriginalReleaseDate.HasValue ? OriginalReleaseDate.Value.ToString("yyyy-MM-dd") : null);
                     appletag.SetDashBox("com.apple.iTunes", "Original Year", OriginalReleaseDate.HasValue ? OriginalReleaseDate.Value.Year.ToString() : null);
                     appletag.SetDashBox("com.apple.iTunes", "MEDIA", Media);
+                    appletag.SetDashBox("com.apple.iTunes", "NARRATOR", Narrator);
+                    appletag.SetDashBox("com.apple.iTunes", "ILLUSTRATOR", Illustrator);
+                }
+
+                // write cover art last so large covr atom doesn't block parsers reading subsequent atoms
+                if (ImageFile.IsNotNullOrWhiteSpace())
+                {
+                    tag.Pictures = new IPicture[1] { new Picture(ImageFile) };
                 }
 
                 file.Save();
@@ -498,6 +545,16 @@ namespace NzbDrone.Core.MediaFiles
             if (Publisher != other.Publisher)
             {
                 output.Add("Label", Tuple.Create(Publisher, other.Publisher));
+            }
+
+            if (Narrator != other.Narrator)
+            {
+                output.Add("Narrator", Tuple.Create(Narrator, other.Narrator));
+            }
+
+            if (Illustrator != other.Illustrator)
+            {
+                output.Add("Illustrator", Tuple.Create(Illustrator, other.Illustrator));
             }
 
             if (!Genres.SequenceEqual(other.Genres))

--- a/src/NzbDrone.Core/MediaFiles/AudioTag.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTag.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -330,6 +331,144 @@ namespace NzbDrone.Core.MediaFiles
             return values?.Select(SanitizeTagValue).Where(v => v != null).ToArray() ?? new string[0];
         }
 
+        internal static void RepairChplAtom(string path)
+        {
+            try
+            {
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var chplOffset = FindNestedAtom(fs, 0, fs.Length, "moov", "udta", "chpl");
+                    if (chplOffset < 0)
+                    {
+                        return;
+                    }
+
+                    // Read the atom size and version to validate the chpl atom.
+                    // TagLib-Sharp corrupts version 1 chpl atoms by rewriting them
+                    // in version 0 format, shifting chapter data. If the file was
+                    // already corrupted and re-saved, the version byte may be any
+                    // garbage value. We validate by checking that:
+                    //   1. Version is 0 or 1 (the only valid versions)
+                    //   2. If version 1: chapter count is sane (reserved=0, count fits atom)
+                    //   3. If version 0: chapter count is sane (count fits atom)
+                    // If anything looks wrong, neutralize the atom.
+                    var sizeBytes = new byte[4];
+                    fs.Seek(chplOffset, SeekOrigin.Begin);
+                    fs.Read(sizeBytes, 0, 4);
+                    var atomSize = (long)((sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3]);
+
+                    fs.Seek(chplOffset + 8, SeekOrigin.Begin);
+                    var version = fs.ReadByte();
+
+                    var shouldNeutralize = false;
+                    if (version > 1)
+                    {
+                        // Invalid version — atom is corrupted
+                        shouldNeutralize = true;
+                    }
+                    else if (version == 0)
+                    {
+                        // Version 0 written by TagLib-Sharp — validate chapter count
+                        fs.Seek(chplOffset + 12, SeekOrigin.Begin);
+                        var countBytes = new byte[4];
+                        fs.Read(countBytes, 0, 4);
+                        var count = (uint)((countBytes[0] << 24) | (countBytes[1] << 16) | (countBytes[2] << 8) | countBytes[3]);
+
+                        // Each chapter is at least 9 bytes (8 timestamp + 1 length).
+                        // Data starts at offset 16 (8 header + 4 ver/flags + 4 count).
+                        var maxChapters = (atomSize - 16) / 9;
+                        if (count > maxChapters || count > 10000)
+                        {
+                            shouldNeutralize = true;
+                        }
+                    }
+
+                    // Version 1 with valid structure is left alone
+                    if (shouldNeutralize)
+                    {
+                        fs.Seek(chplOffset + 4, SeekOrigin.Begin);
+                        fs.Write(new byte[] { 0x66, 0x72, 0x65, 0x65 }, 0, 4); // "free"
+                        Logger.Debug("Neutralized corrupted chpl atom (version={0}) in {1}", version, path);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "Failed to repair chpl atom in {0}", path);
+            }
+        }
+
+        internal static long FindNestedAtom(Stream stream, long start, long end, params string[] atomPath)
+        {
+            if (atomPath.Length == 0)
+            {
+                return start;
+            }
+
+            var target = atomPath[0];
+            var remaining = new string[atomPath.Length - 1];
+            Array.Copy(atomPath, 1, remaining, 0, remaining.Length);
+
+            var buffer = new byte[8];
+            var pos = start;
+
+            while (pos < end - 7)
+            {
+                stream.Seek(pos, SeekOrigin.Begin);
+                if (stream.Read(buffer, 0, 8) < 8)
+                {
+                    break;
+                }
+
+                var size = (long)((buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3]);
+                var type = System.Text.Encoding.ASCII.GetString(buffer, 4, 4);
+
+                long headerSize = 8;
+                if (size == 1)
+                {
+                    // 64-bit extended size
+                    var extBuf = new byte[8];
+                    if (stream.Read(extBuf, 0, 8) < 8)
+                    {
+                        break;
+                    }
+
+                    size = ((long)extBuf[0] << 56) | ((long)extBuf[1] << 48) |
+                           ((long)extBuf[2] << 40) | ((long)extBuf[3] << 32) |
+                           ((long)extBuf[4] << 24) | ((long)extBuf[5] << 16) |
+                           ((long)extBuf[6] << 8) | extBuf[7];
+                    headerSize = 16;
+                }
+                else if (size == 0)
+                {
+                    size = end - pos;
+                }
+                else if (size < 8)
+                {
+                    break;
+                }
+
+                if (pos + size > end)
+                {
+                    break;
+                }
+
+                if (type == target)
+                {
+                    if (remaining.Length == 0)
+                    {
+                        return pos;
+                    }
+
+                    return FindNestedAtom(stream, pos + headerSize, pos + size, remaining);
+                }
+
+                pos += size;
+            }
+
+            return -1;
+        }
+
         public void Write(string path)
         {
             Logger.Debug($"Starting tag write for {path}");
@@ -344,6 +483,7 @@ namespace NzbDrone.Core.MediaFiles
             BookAuthors = SanitizeTagValues(BookAuthors);
             Genres = SanitizeTagValues(Genres);
 
+            var isApple = false;
             TagLib.File file = null;
             try
             {
@@ -436,6 +576,8 @@ namespace NzbDrone.Core.MediaFiles
                     tag.Pictures = new IPicture[1] { new Picture(ImageFile) };
                 }
 
+                isApple = file.TagTypes.HasFlag(TagTypes.Apple);
+
                 file.Save();
             }
             catch (CorruptFileException ex)
@@ -452,6 +594,15 @@ namespace NzbDrone.Core.MediaFiles
             finally
             {
                 file?.Dispose();
+            }
+
+            // TagLib-Sharp corrupts Nero chapter (chpl) atoms by rewriting version 1
+            // atoms in version 0 format, shifting all chapter data. This causes readers
+            // like ATL/Jellyfin that parse chpl before ilst to fail to read any metadata.
+            // Neutralize the corrupted atom by replacing it with a free atom.
+            if (isApple)
+            {
+                RepairChplAtom(path);
             }
         }
 

--- a/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTagService.cs
@@ -113,6 +113,8 @@ namespace NzbDrone.Core.MediaFiles
                 OriginalYear = (uint)(book.ReleaseDate?.Year ?? 0),
                 Publisher = edition.Publisher,
                 Genres = new string[0],
+                Narrator = edition.Credits?.FirstOrDefault(c => c.Role.Equals("Narrator", StringComparison.OrdinalIgnoreCase))?.Name,
+                Illustrator = edition.Credits?.FirstOrDefault(c => c.Role.Equals("Illustrator", StringComparison.OrdinalIgnoreCase))?.Name,
                 ImageFile = imageFile,
                 ImageSize = imageSize,
             };

--- a/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
@@ -515,11 +515,12 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
             }
 
             var authors = resource.Authors.Select(MapAuthorMetadata).ToDictionary(x => x.ForeignAuthorId, x => x);
+            var authorNames = resource.Authors.ToDictionary(x => x.ForeignId.ToString(), x => x.Name);
             var series = resource.Series.Select(MapSeries).ToList();
 
             foreach (var work in resource.Works)
             {
-                var book = MapBook(work);
+                var book = MapBook(work, authorNames);
                 var authorId = work.Books.OrderByDescending(b => b.AverageRating * b.RatingCount).First().Contributors.First().ForeignId.ToString();
 
                 AddDbIds(authorId, book, authors);
@@ -800,7 +801,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
 
             var books = resource.Works
                 .Where(x => x.ForeignId > 0 && GetAuthorId(x) == resource.ForeignId)
-                .Select(MapBook)
+                .Select(x => MapBook(x))
                 .ToList();
 
             books.ForEach(x => x.AuthorMetadata = metadata);
@@ -864,7 +865,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
             return series;
         }
 
-        private static Book MapBook(WorkResource resource)
+        private static Book MapBook(WorkResource resource, Dictionary<string, string> authorNames = null)
         {
             var book = new Book
             {
@@ -881,7 +882,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
 
             if (resource.Books != null)
             {
-                book.Editions = resource.Books.Select(x => MapEdition(x)).ToList();
+                book.Editions = resource.Books.Select(x => MapEdition(x, authorNames)).ToList();
 
                 // monitor the most popular release
                 var mostPopular = book.Editions.Value.MaxBy(x => x.Ratings.Popularity);
@@ -944,7 +945,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
             return book;
         }
 
-        private static Edition MapEdition(BookResource resource)
+        private static Edition MapEdition(BookResource resource, Dictionary<string, string> authorNames = null)
         {
             var edition = new Edition
             {
@@ -963,6 +964,19 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
                 ReleaseDate = resource.ReleaseDate,
                 Ratings = new Ratings { Votes = resource.RatingCount, Value = (decimal)resource.AverageRating }
             };
+
+            if (resource.Contributors != null && authorNames != null)
+            {
+                edition.Credits = resource.Contributors
+                    .Where(c => c.Role.IsNotNullOrWhiteSpace() &&
+                                !c.Role.Equals("Author", StringComparison.OrdinalIgnoreCase))
+                    .Select(c => new Credit
+                    {
+                        Name = authorNames.GetValueOrDefault(c.ForeignId.ToString(), "Unknown"),
+                        Role = c.Role
+                    })
+                    .ToList();
+            }
 
             if (resource.ImageUrl.IsNotNullOrWhiteSpace())
             {

--- a/src/Readarr.Api.V1/Books/EditionResource.cs
+++ b/src/Readarr.Api.V1/Books/EditionResource.cs
@@ -28,6 +28,7 @@ namespace Readarr.Api.V1.Books
         public List<MediaCover> Images { get; set; }
         public List<Links> Links { get; set; }
         public Ratings Ratings { get; set; }
+        public List<Credit> Credits { get; set; }
         public bool Monitored { get; set; }
         public bool ManualAdd { get; set; }
         public string RemoteCover { get; set; }
@@ -67,6 +68,7 @@ namespace Readarr.Api.V1.Books
                 Images = model.Images,
                 Links = model.Links,
                 Ratings = model.Ratings,
+                Credits = model.Credits,
                 Monitored = model.Monitored,
                 ManualAdd = model.ManualAdd
             };
@@ -99,6 +101,7 @@ namespace Readarr.Api.V1.Books
                 Images = resource.Images,
                 Links = resource.Links,
                 Ratings = resource.Ratings,
+                Credits = resource.Credits ?? new List<Credit>(),
                 Monitored = resource.Monitored,
                 ManualAdd = resource.ManualAdd
             };


### PR DESCRIPTION
### Persist Credits

**Before:** Editions only stored author info. Non-author contributors like narrators and illustrators from the BookInfo API were discarded.

**Now:** Editions have a `Credits` list that captures non-author contributors (narrator, illustrator, editor, etc.) from the BookInfo API. These are stored as JSON in the database and exposed through the API.

### Audio tag writing — narrator/illustrator

**Before:** Audio files had no narrator or illustrator tags.

**Now:** Narrator and illustrator are read from edition credits and written to all 5 tag formats (ID3v2 TXXX frames, Xiph fields, APE items, ASF descriptors, Apple dash boxes). The Diff method also tracks changes to these fields.

### Audio tag writing — cover art atom ordering fix

**Before:** Cover art was written in the middle of tag assignment, before format-specific tags. In M4B files this put the large `covr` atom before `aART`, `trkn`, `©day`, and all `----` dash boxes. Some parsers (ATL) stop reading ilst children after a large covr atom and miss everything after it.

**Now:** Cover art is written last, after all format-specific tags. The `covr` atom lands at the end of the ilst container so all metadata atoms precede it.

### Audio tag writing — null byte sanitization

**Before:** String values from the database were written to tags as-is. If a field contained null bytes or other control characters (e.g. Dungeon Crawler Carl's description), they were embedded into the file, corrupting the tag.

**Now:** All string fields are stripped of null bytes and C0 control characters (except tab/newline/CR) before writing. Empty results become null so nothing is written.

### Docker dev build

**Before:** No way to build a Docker image without host tools. The existing Dockerfile expected pre-built artifacts.

**Now:** `docker/Dockerfile.dev` is a multi-stage build (dotnet SDK → node → alpine runtime) that compiles everything inside Docker. Copies `.editorconfig` and `Logo/` which are required for the build but live outside `src/`.