### PR TITLE
Increase Hardcover GraphQL request timeout to 300s

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Hardcover/HardcoverProxy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -94,6 +95,7 @@ namespace NzbDrone.Core.ImportLists.Hardcover
                 .KeepAlive()
                 .Build();
 
+            request.RequestTimeout = TimeSpan.FromSeconds(300);
             request.SetContent(query);
             return request;
         }


### PR DESCRIPTION
## Summary

- The default HTTP client timeout (100s) was insufficient for Hardcover's API under load
- This caused 408 RequestTimeout errors when fetching lists during import list setup
- Sets `RequestTimeout` to 300s on Hardcover GraphQL requests, matching the timeout used elsewhere in the codebase for long-running HTTP calls

Fixes #143

## Test plan

- [ ] Add a Hardcover import list — "Get Lists" should no longer time out
- [ ] Verify the list dropdown populates correctly