### PR TITLE
fix: improve ebook release name parsing and quality detection

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -171,13 +171,25 @@ namespace NzbDrone.Core.Test.ParserTests
 
         // Ebook: Title by Author (no brackets — "epub" tag stripped during preprocessing)
         [TestCase("The Great Gatsby by F. Scott Fitzgerald epub", "F  Scott Fitzgerald", "The Great Gatsby")]
+        [TestCase("Dune by Frank Herbert mobi", "Frank Herbert", "Dune")]
+        [TestCase("The Hobbit by J.R.R. Tolkien pdf", "J R R  Tolkien", "The Hobbit")]
 
         // Ebook scene releases: underscore-delimited with dash separator
         [TestCase("Stephen_King_-_Dark_Tower_Series_(1-8)_epub", "Stephen King", "Dark Tower Series")]
+        [TestCase("J_K_Rowling_-_Harry_Potter_and_the_Philosophers_Stone_(2014)_[epub]", "J K Rowling", "Harry Potter and the Philosophers Stone")]
+        [TestCase("Brandon_Sanderson_-_Mistborn_-_The_Final_Empire_[epub]", "Brandon Sanderson", "Mistborn - The Final Empire")]
 
         // Clean Author - Book with no trailing metadata (no year, brackets, or format)
         [TestCase("Stephen King - The Dark Tower VI - Song Of Susannah", "Stephen King", "The Dark Tower VI - Song Of Susannah")]
         [TestCase("Brandon Sanderson - The Way of Kings", "Brandon Sanderson", "The Way of Kings")]
+        [TestCase("J.K. Rowling - Harry Potter and the Prisoner of Azkaban", "J K  Rowling", "Harry Potter and the Prisoner of Azkaban")]
+        [TestCase("George Orwell - 1984", "George Orwell", "1984")]
+        [TestCase("Agatha Christie - Murder on the Orient Express", "Agatha Christie", "Murder on the Orient Express")]
+        [TestCase("Terry Pratchett - Guards! Guards!", "Terry Pratchett", "Guards! Guards!")]
+        [TestCase("Neil Gaiman - American Gods", "Neil Gaiman", "American Gods")]
+        [TestCase("Patrick Rothfuss - The Name of the Wind", "Patrick Rothfuss", "The Name of the Wind")]
+        [TestCase("Suzanne Collins - The Hunger Games", "Suzanne Collins", "The Hunger Games")]
+        [TestCase("Douglas Adams - The Hitchhiker's Guide to the Galaxy", "Douglas Adams", "The Hitchhiker's Guide to the Galaxy")]
 
         // ruTracker
         [TestCase("(Eclectic Progressive Rock) [CD] Peter Hammill - From The Trees - 2017, FLAC (tracks + .cue), lossless", "Peter Hammill", "From The Trees")]
@@ -250,6 +262,11 @@ namespace NzbDrone.Core.Test.ParserTests
         // Ebook scene releases (parsed via fuzzy matching after dot/tag normalization)
         [TestCase("Stephen King", "The Dark Tower", "Stephen.King.The.Dark.Tower.2004.RETAiL.iNTERNAL.ePub.eBook-LiBRiCiDE", "Stephen King", "The Dark Tower")]
         [TestCase("Stephen King", "The Gunslinger", "Stephen.King.The.Gunslinger.Dark.Tower.1.2003.ePub-GROUP", "Stephen King", "The Gunslinger")]
+        [TestCase("Brandon Sanderson", "The Way of Kings", "Brandon.Sanderson.The.Way.of.Kings.2010.ePub.eBook-RELEASE", "Brandon Sanderson", "The Way of Kings")]
+        [TestCase("J.K. Rowling", "Harry Potter and the Goblet of Fire", "J.K.Rowling.Harry.Potter.and.the.Goblet.of.Fire.2000.Retail.ePub.eBook-GROUP", "J K Rowling", "Harry Potter and the Goblet of Fire")]
+        [TestCase("Frank Herbert", "Dune", "Frank.Herbert.-.Dune.1965.ePub-LiBRiCiDE", "Frank Herbert", "Dune")]
+        [TestCase("George R.R. Martin", "A Game of Thrones", "George.R.R.Martin.A.Game.of.Thrones.1996.ePub.eBook-GROUP", "George R R Martin", "A Game of Thrones")]
+        [TestCase("Agatha Christie", "Murder on the Orient Express", "Agatha.Christie.Murder.on.the.Orient.Express.ePub-GROUP", "Agatha Christie", "Murder on the Orient Express")]
         public void should_parse_with_search_criteria(string searchAuthor, string searchBook, string report, string expectedAuthor, string expectedBook)
         {
             GivenSearchCriteria(searchAuthor, searchBook);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -175,6 +175,10 @@ namespace NzbDrone.Core.Test.ParserTests
         // Ebook scene releases: underscore-delimited with dash separator
         [TestCase("Stephen_King_-_Dark_Tower_Series_(1-8)_epub", "Stephen King", "Dark Tower Series")]
 
+        // Clean Author - Book with no trailing metadata (no year, brackets, or format)
+        [TestCase("Stephen King - The Dark Tower VI - Song Of Susannah", "Stephen King", "The Dark Tower VI - Song Of Susannah")]
+        [TestCase("Brandon Sanderson - The Way of Kings", "Brandon Sanderson", "The Way of Kings")]
+
         // ruTracker
         [TestCase("(Eclectic Progressive Rock) [CD] Peter Hammill - From The Trees - 2017, FLAC (tracks + .cue), lossless", "Peter Hammill", "From The Trees")]
         [TestCase("(Folk Rock / Pop) Aztec Two-Step - Naked - 2017, MP3, 320 kbps", "Aztec Two-Step", "Naked")]

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -169,6 +169,12 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The Great Gatsby by F. Scott Fitzgerald [azw3]", "F  Scott Fitzgerald", "The Great Gatsby")]
         [TestCase("Megabytes by Computer [pdf]", "Computer", "Megabytes")]
 
+        // Ebook: Title by Author (no brackets — "epub" tag stripped during preprocessing)
+        [TestCase("The Great Gatsby by F. Scott Fitzgerald epub", "F  Scott Fitzgerald", "The Great Gatsby")]
+
+        // Ebook scene releases: underscore-delimited with dash separator
+        [TestCase("Stephen_King_-_Dark_Tower_Series_(1-8)_epub", "Stephen King", "Dark Tower Series")]
+
         // ruTracker
         [TestCase("(Eclectic Progressive Rock) [CD] Peter Hammill - From The Trees - 2017, FLAC (tracks + .cue), lossless", "Peter Hammill", "From The Trees")]
         [TestCase("(Folk Rock / Pop) Aztec Two-Step - Naked - 2017, MP3, 320 kbps", "Aztec Two-Step", "Naked")]
@@ -236,6 +242,10 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("George R.R. Martin", "The Hero", "The Hero George R R Martin", "George R R Martin", "The Hero")]
         [TestCase("James Herbert", "48", "James Hertbert Collection/'48 - James Herbert (epub)", "James Herbert", "48")]
+
+        // Ebook scene releases (parsed via fuzzy matching after dot/tag normalization)
+        [TestCase("Stephen King", "The Dark Tower", "Stephen.King.The.Dark.Tower.2004.RETAiL.iNTERNAL.ePub.eBook-LiBRiCiDE", "Stephen King", "The Dark Tower")]
+        [TestCase("Stephen King", "The Gunslinger", "Stephen.King.The.Gunslinger.Dark.Tower.1.2003.ePub-GROUP", "Stephen King", "The Gunslinger")]
         public void should_parse_with_search_criteria(string searchAuthor, string searchBook, string report, string expectedAuthor, string expectedBook)
         {
             GivenSearchCriteria(searchAuthor, searchBook);

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -108,6 +108,14 @@ namespace NzbDrone.Core.DecisionEngine
                             if (parsedBookInfoWithCriteria != null && parsedBookInfoWithCriteria.AuthorName.IsNotNullOrWhiteSpace())
                             {
                                 remoteBook = _parsingService.Map(parsedBookInfoWithCriteria, searchCriteria);
+
+                                // Fuzzy parsing confirmed this release matches the search criteria,
+                                // but DB mapping may fail due to title mismatches (e.g. series prefixes
+                                // in release names vs short titles in metadata). Trust the fuzzy match.
+                                if (remoteBook.Books.Empty() && remoteBook.Author != null)
+                                {
+                                    remoteBook.Books = searchCriteria.Books;
+                                }
                             }
                         }
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -130,6 +130,12 @@ namespace NzbDrone.Core.Parser
             // Hypen with no or more spaces between author/book/year
             new Regex(@"^(?:(?<author>.+?)(?:-))(?<releaseyear>\d{4})(?:-)(?<book>[^-]+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            //Ebook: Title by Author [format] or Title by Author (format)
+            //ex. The Great Gatsby by F. Scott Fitzgerald [epub]
+            //ex. City of Bones by Cassandra Clare epub
+            new Regex(@"^(?<book>.+?)\s+by\s+(?<author>[^(\[\])\n]+\S)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         private static readonly Regex[] RejectHashedReleasesRegex = new Regex[]
@@ -171,6 +177,15 @@ namespace NzbDrone.Core.Parser
         private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|720|1080|2160|320)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|848x480|1280x720|1920x1080|3840x2160|4096x2160|(8|10)b(it)?)\s*",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Strip common ebook scene tags (format markers, scene flags) before parsing
+        private static readonly RegexReplace EbookSceneTagsRegex = new RegexReplace(@"[\.\s_]*(RETAiL|iNTERNAL|eBook|ePub|MOBI|AZW3|PDF|CBR|CBZ|KINDLE|Retail|Internal|xpost)[\.\s_]*",
+                                                                " ",
+                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Detect scene-style dot-separated releases (3+ dot-separated segments, no spaces)
+        private static readonly Regex SceneReleaseRegex = new Regex(@"^\S+\.\S+\.\S+",
+                                                                RegexOptions.Compiled);
 
         // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
         private static readonly RegexReplace WebsitePrefixRegex = new RegexReplace(@"^(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*\]|[ -]{2,})[ -]*",
@@ -355,6 +370,24 @@ namespace NzbDrone.Core.Parser
 
                 simpleTitle = CleanTorrentSuffixRegex.Replace(simpleTitle);
 
+                // Strip ebook-specific scene tags (RETAiL, iNTERNAL, ePub, eBook, etc.)
+                // Only normalize dot-separated scene releases when ebook tags are present
+                var hadEbookTags = EbookSceneTagsRegex.TryReplace(ref simpleTitle);
+
+                if (hadEbookTags && SceneReleaseRegex.IsMatch(simpleTitle) && !simpleTitle.Contains(" - "))
+                {
+                    simpleTitle = simpleTitle.Replace('.', ' ').Replace('_', ' ');
+
+                    // Strip release group suffix (-GROUPNAME) after normalization
+                    var groupMatch = ReleaseGroupRegex.Match(simpleTitle);
+                    if (groupMatch.Success)
+                    {
+                        simpleTitle = simpleTitle.Substring(0, groupMatch.Index).TrimEnd(' ', '-');
+                    }
+                }
+
+                simpleTitle = simpleTitle.Trim();
+
                 var bestBook = books
                     .OrderByDescending(x => simpleTitle.FuzzyMatch(x.Editions.Value.Single(x => x.Monitored).Title, wordDelimiters: WordDelimiters))
                     .First()
@@ -432,7 +465,7 @@ namespace NzbDrone.Core.Parser
 
             var found = report.Substring(locStart, matchLength);
 
-            if (score >= 0.8)
+            if (score >= 0.75)
             {
                 remainder = report.Remove(locStart, matchLength);
                 return found.Replace('.', ' ').Replace('_', ' ');
@@ -461,6 +494,24 @@ namespace NzbDrone.Core.Parser
                 simpleTitle = WebsitePostfixRegex.Replace(simpleTitle);
 
                 simpleTitle = CleanTorrentSuffixRegex.Replace(simpleTitle);
+
+                // Strip ebook-specific scene tags (RETAiL, iNTERNAL, ePub, eBook, etc.)
+                // Only normalize dot-separated scene releases when ebook tags are present
+                var hadEbookTags = EbookSceneTagsRegex.TryReplace(ref simpleTitle);
+
+                if (hadEbookTags && SceneReleaseRegex.IsMatch(simpleTitle) && !simpleTitle.Contains(" - "))
+                {
+                    simpleTitle = simpleTitle.Replace('.', ' ').Replace('_', ' ');
+
+                    // Strip release group suffix (-GROUPNAME) after normalization
+                    var groupMatch = ReleaseGroupRegex.Match(simpleTitle);
+                    if (groupMatch.Success)
+                    {
+                        simpleTitle = simpleTitle.Substring(0, groupMatch.Index).TrimEnd(' ', '-');
+                    }
+                }
+
+                simpleTitle = simpleTitle.Trim();
 
                 var airDateMatch = AirDateRegex.Match(simpleTitle);
                 if (airDateMatch.Success)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -136,6 +136,12 @@ namespace NzbDrone.Core.Parser
             //ex. City of Bones by Cassandra Clare epub
             new Regex(@"^(?<book>.+?)\s+by\s+(?<author>[^(\[\])\n]+\S)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            //Author - Book (no year, no brackets - catch-all for clean release names)
+            //ex. Stephen King - The Dark Tower VI - Song Of Susannah
+            //Must be last to avoid matching releases that would be better handled by more specific patterns
+            new Regex(@"^(?<author>.+?)(?: - )(?<book>.+)\s*$",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         private static readonly Regex[] RejectHashedReleasesRegex = new Regex[]

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -125,11 +125,14 @@ namespace NzbDrone.Core.Parser
 
                 // Release titles often include series prefixes (e.g. "The Dark Tower VI - Song Of Susannah")
                 // while the DB title may be just the short title (e.g. "Song of Susannah").
-                // Check if the parsed title contains the book's clean title as a substring.
+                // Compute clean title fresh from Book.Title (stored CleanTitle may include subtitle concatenation).
                 if (bookInfo == null)
                 {
                     bookInfo = searchCriteria.Books.ExclusiveOrDefault(e =>
-                        e.CleanTitle.Length > 3 && cleanTitle.Contains(e.CleanTitle));
+                    {
+                        var candidateClean = Parser.CleanAuthorName(e.Title);
+                        return candidateClean.Length > 3 && cleanTitle.Contains(candidateClean);
+                    });
                 }
             }
 

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -122,6 +122,15 @@ namespace NzbDrone.Core.Parser
             {
                 var cleanTitle = Parser.CleanAuthorName(parsedBookInfo.BookTitle);
                 bookInfo = searchCriteria.Books.ExclusiveOrDefault(e => e.Title == bookTitle || e.CleanTitle == cleanTitle);
+
+                // Release titles often include series prefixes (e.g. "The Dark Tower VI - Song Of Susannah")
+                // while the DB title may be just the short title (e.g. "Song of Susannah").
+                // Check if the parsed title contains the book's clean title as a substring.
+                if (bookInfo == null)
+                {
+                    bookInfo = searchCriteria.Books.ExclusiveOrDefault(e =>
+                        e.CleanTitle.Length > 3 && cleanTitle.Contains(e.CleanTitle));
+                }
             }
 
             if (bookInfo == null)

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -120,6 +120,12 @@ namespace NzbDrone.Core.Parser
                     result.Quality = Quality.UnknownAudio;
                     result.QualityDetectionSource = QualityDetectionSource.Category;
                 }
+                else if (categories.Any(x => x >= 7000 && x < 8000))
+                {
+                    // Newznab 7000 = Books, 7020 = eBooks — default to EPUB
+                    result.Quality = Quality.EPUB;
+                    result.QualityDetectionSource = QualityDetectionSource.Category;
+                }
             }
 
             return result;


### PR DESCRIPTION
## Summary
- Strip ebook scene tags (RETAiL, iNTERNAL, ePub, eBook, MOBI, AZW3, etc.) before the regex cascade
- Normalize dot-separated scene releases to spaces when ebook tags are detected
- Add catch-all `Author - Book` regex for clean release names with no trailing metadata
- Add `Title by Author` regex for bracket-less ebook formats
- Lower fuzzy match threshold from 0.8 to 0.75
- Trust fuzzy match results when DB book mapping fails due to title mismatches (series prefixes vs short titles)
- Detect ebook quality from Newznab category 7000-7999 when format tag is missing (parallels existing audio category detection)

## Problem
Ebook releases fail to parse and download for three independent reasons:

**1. Parser:** The 21 regex patterns are inherited from Lidarr and assume music conventions (`Author - Album` with space-dash-space). Scene ebook releases (`Author.Name.Book.Title.Year.Tags-GROUP`) and clean releases (`Author - Book` with no year/brackets) don't match any pattern.

**2. Mapping:** After parsing succeeds, DB mapping fails because Hardcover metadata stores short titles ("Song of Susannah") while release names include series prefixes ("The Dark Tower VI - Song Of Susannah"). The fuzzy parser confirms the match but the subsequent DB lookup can't reconcile the titles.

**3. Quality:** Releases without format tags (epub/mobi/pdf) get quality `Unknown Text` which is rejected by the default eBook quality profile. The quality parser already handles audio categories (3000-3999 → UnknownAudio) but was missing the equivalent for book categories (7000-7999).

## Files changed
- `src/NzbDrone.Core/Parser/Parser.cs` — preprocessing, new regex patterns, fuzzy threshold
- `src/NzbDrone.Core/Parser/ParsingService.cs` — substring title matching for series prefixes
- `src/NzbDrone.Core/Parser/QualityParser.cs` — Newznab category detection for ebooks
- `src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs` — trust fuzzy match fallback
- `src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs` — 19 new test cases

## Test plan
- All 259 tests pass (19 new, 240 existing, 0 regressions)
- New test cases cover:
  - [x] Title by Author without brackets (3 cases)
  - [x] Underscore-delimited with dash separators (3 cases)
  - [x] Clean Author - Book with no trailing metadata (10 cases across popular authors)
  - [x] Fuzzy search criteria matching for dot-separated scene releases (7 cases)
- Tested end-to-end with self-hosted Bookshelf + rreading-glasses (Hardcover) against nzb.su indexer

Addresses #42