### PR TITLE
Paginate large Goodreads series

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Goodreads/Series/GoodreadsSeriesImportList.cs
+++ b/src/NzbDrone.Core/ImportLists/Goodreads/Series/GoodreadsSeriesImportList.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using FluentValidation.Results;
 using NLog;
@@ -36,18 +37,19 @@ namespace NzbDrone.Core.ImportLists.Goodreads
 
             try
             {
-                var series = _seriesInfo.GetSeriesInfo(Settings.SeriesId);
-
-                foreach (var work in series.Works)
+                var pageNum = 1;
+                while (true)
                 {
-                    result.Add(new ImportListItemInfo
+                    var page = FetchPage(pageNum++);
+
+                    if (page.Any())
                     {
-                        BookGoodreadsId = work.Id.ToString(),
-                        Book = work.OriginalTitle,
-                        EditionGoodreadsId = work.BestBook.Id.ToString(),
-                        Author = work.BestBook.AuthorName,
-                        AuthorGoodreadsId = work.BestBook.AuthorId.ToString()
-                    });
+                        result.AddRange(page);
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 _importListStatusService.RecordSuccess(Definition.Id);
@@ -60,6 +62,26 @@ namespace NzbDrone.Core.ImportLists.Goodreads
             return CleanupListItems(result);
         }
 
+        private List<ImportListItemInfo> FetchPage(int page)
+        {
+            var series = _seriesInfo.GetSeriesInfo(Settings.SeriesId, page);
+            var result = new List<ImportListItemInfo>();
+
+            foreach (var work in series.Works)
+            {
+                result.Add(new ImportListItemInfo
+                {
+                    BookGoodreadsId = work.Id.ToString(),
+                    Book = work.OriginalTitle,
+                    EditionGoodreadsId = work.BestBook.Id.ToString(),
+                    Author = work.BestBook.AuthorName,
+                    AuthorGoodreadsId = work.BestBook.AuthorId.ToString()
+                });
+            }
+
+            return result;
+        }
+
         protected override void Test(List<ValidationFailure> failures)
         {
             failures.AddIfNotNull(TestConnection());
@@ -69,7 +91,7 @@ namespace NzbDrone.Core.ImportLists.Goodreads
         {
             try
             {
-                _seriesInfo.GetSeriesInfo(Settings.SeriesId);
+                _seriesInfo.GetSeriesInfo(Settings.SeriesId, 1);
                 return null;
             }
             catch (HttpException e)

--- a/src/NzbDrone.Core/MetadataSource/Goodreads/GoodreadsProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/Goodreads/GoodreadsProxy.cs
@@ -37,13 +37,14 @@ namespace NzbDrone.Core.MetadataSource.Goodreads
                 .CreateFactory();
         }
 
-        public SeriesResource GetSeriesInfo(int foreignSeriesId, bool useCache = false)
+        public SeriesResource GetSeriesInfo(int foreignSeriesId, int page, bool useCache = false)
         {
             _logger.Debug("Getting Series with GoodreadsId of {0}", foreignSeriesId);
 
             var httpRequest = _requestBuilder.Create()
                 .SetSegment("route", $"series/{foreignSeriesId}")
                 .AddQueryParam("format", "xml")
+                .AddQueryParam("page", page)
                 .Build();
 
             httpRequest.AllowAutoRedirect = true;

--- a/src/NzbDrone.Core/MetadataSource/IProvideSeriesInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideSeriesInfo.cs
@@ -4,6 +4,6 @@ namespace NzbDrone.Core.MetadataSource
 {
     public interface IProvideSeriesInfo
     {
-        SeriesResource GetSeriesInfo(int id, bool useCache = true);
+        SeriesResource GetSeriesInfo(int id, int page, bool useCache = true);
     }
 }


### PR DESCRIPTION
Currently Goodreads series import only handles first page (first 100 items in series).
This PR adds iterating over all pages (similar to goodreads list) and import all possible books in series.