### PR TITLE
fix: update Inno Setup download URL to GitHub archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ _temp_*/**/*
 
 _cache/
 _temp/
+
+# Portable Inno Setup install (downloaded by build.sh --installer)
+_inno/

--- a/build.sh
+++ b/build.sh
@@ -254,7 +254,9 @@ InstallInno()
     ProgressStart "Installing portable Inno Setup"
 
     rm -rf _inno
-    curl -s --output innosetup.exe "https://files.jrsoftware.org/is/6/innosetup-${INNOVERSION:-6.2.0}.exe"
+    local inno_ver="${INNOVERSION:-6.2.0}"
+    local inno_tag="is-${inno_ver//./_}"
+    curl -sL --output innosetup.exe "https://github.com/jrsoftware/issrc/releases/download/${inno_tag}/innosetup-${inno_ver}.exe"
     mkdir _inno
     ./innosetup.exe //portable=1 //silent //currentuser //dir=.\\_inno
     rm innosetup.exe


### PR DESCRIPTION
## Summary

`build.sh`'s `InstallInno` function downloads a portable Inno Setup build before compiling the Windows installer. The URL it uses — `https://files.jrsoftware.org/is/6/innosetup-<version>.exe` — has been removed upstream. All older 6.x release paths there now return HTTP 404, and because `curl -s` saves the response body unconditionally, the script writes the 404 HTML page to `innosetup.exe` and then fails extraction with `syntax error near unexpected token 'newline'` when attempting the portable install.

This PR switches the download URL to the [GitHub releases archive](https://github.com/jrsoftware/issrc/releases/download/is-6_2_0/innosetup-6.2.0.exe), which continues to host every historical Inno Setup 6.x build including the pinned 6.2.0.

## Changes

- `build.sh` — `InstallInno` now resolves the version into both the tag form (`is-6_2_0`) and the filename form (`6.2.0`) from a single `${INNOVERSION:-6.2.0}` variable, then curls from the GitHub archive with `-L` so the 302 to the CDN is followed.
- `.gitignore` — adds `_inno/` since that's where `InstallInno` extracts the portable Inno tree, and it shouldn't be tracked.

## Test plan

- [x] `./build.sh --installer` now downloads Inno Setup successfully (no HTML saved as .exe)
- [x] The portable Inno Setup extracts into `./_inno/` correctly
- [x] ISCC.exe compiles `readarr.iss` against staged win-x64 artifacts, produces `Readarr.<version>.win-x64.exe`
- [x] No change to the resulting installer contents or behavior — this is purely a download-URL fix

Verified on Windows Server 2022 with Git Bash.