### PR TITLE
feat: add pre-upgrade backup and auto-rollback to Windows installer

### DIFF
--- a/distribution/windows/setup/Rollback-To-Pre-Upgrade.bat
+++ b/distribution/windows/setup/Rollback-To-Pre-Upgrade.bat
@@ -1,0 +1,21 @@
+@echo off
+echo ============================================================
+echo  Readarr Rollback - Restore to Pre-Upgrade State
+echo ============================================================
+echo.
+echo This will:
+echo   1. Stop the Readarr service
+echo   2. Restore binaries and data from the most recent pre-upgrade backup
+echo   3. Start the Readarr service
+echo.
+set /p confirm="Continue? (Y/N): "
+if /i not "%confirm%"=="Y" (
+    echo Cancelled.
+    pause
+    exit /b 0
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0upgrade-helpers\rollback.ps1"
+
+echo.
+pause

--- a/distribution/windows/setup/readarr.iss
+++ b/distribution/windows/setup/readarr.iss
@@ -54,12 +54,18 @@ Name: "{app}"; Permissions: users-modify
 [Files]
 Source: "..\..\..\_artifacts\{#Runtime}\{#Framework}\Readarr\Readarr.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "..\..\..\_artifacts\{#Runtime}\{#Framework}\Readarr\*"; Excludes: "Readarr.Update"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Upgrade safety: backup + rollback helpers
+Source: "upgrade-helpers\do-backup.ps1"; Flags: dontcopy
+Source: "upgrade-helpers\rollback.ps1"; Flags: dontcopy
+Source: "upgrade-helpers\rollback.ps1"; DestDir: "{app}\bin\upgrade-helpers"; Flags: ignoreversion
+Source: "Rollback-To-Pre-Upgrade.bat"; DestDir: "{app}\bin"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\bin\{#AppExeName}"; Parameters: "/icon"
 Name: "{commondesktop}\{#AppName}"; Filename: "{app}\bin\{#AppExeName}"; Parameters: "/icon"; Tasks: desktopIcon
 Name: "{userstartup}\{#AppName}"; Filename: "{app}\bin\Readarr.exe"; WorkingDir: "{app}\bin"; Tasks: startupShortcut
+Name: "{group}\Rollback To Pre-Upgrade"; Filename: "{app}\bin\Rollback-To-Pre-Upgrade.bat"; WorkingDir: "{app}\bin"
 
 [InstallDelete]
 Name: "{app}\bin"; Type: filesandordirs
@@ -75,10 +81,117 @@ Filename: "{app}\bin\Readarr.exe"; Description: "Start Readarr"; Flags: postinst
 Filename: "{app}\bin\readarr.console.exe"; Parameters: "/u"; Flags: waituntilterminated skipifdoesntexist
 
 [Code]
+const
+  REG_KEY = 'SOFTWARE\Readarr\Upgrade';
+
+var
+  GlobalBackupMethod: String;
+  GlobalBackupPath: String;
+
+function ExtractJsonValue(const Json, Key: String): String;
+var
+  Pattern, Remainder: String;
+  StartIdx, EndIdx: Integer;
+begin
+  Result := '';
+  Pattern := '"' + Key + '":"';
+  StartIdx := Pos(Pattern, Json);
+  if StartIdx = 0 then Exit;
+  StartIdx := StartIdx + Length(Pattern);
+  Remainder := Copy(Json, StartIdx, Length(Json));
+  EndIdx := Pos('"', Remainder);
+  if EndIdx = 0 then Exit;
+  Result := Copy(Remainder, 1, EndIdx - 1);
+  StringChangeEx(Result, '\\', '\', True);
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
+  BackupScript, TempResult, OldExe, OldVer: String;
+  JsonContent: AnsiString;
 begin
-  Exec('net', 'stop readarr', '', 0, ewWaitUntilTerminated, ResultCode)
-  Exec('sc', 'delete readarr', '', 0, ewWaitUntilTerminated, ResultCode)
+  Result := '';
+
+  // Backup existing Readarr before any destructive install step
+  if FileExists(ExpandConstant('{commonappdata}\Readarr\config.xml')) then
+  begin
+    ExtractTemporaryFile('do-backup.ps1');
+    ExtractTemporaryFile('rollback.ps1');
+    BackupScript := ExpandConstant('{tmp}\do-backup.ps1');
+    TempResult := ExpandConstant('{tmp}\backup-result.json');
+
+    Exec(ExpandConstant('{cmd}'),
+         '/c powershell -NoProfile -ExecutionPolicy Bypass -File "' + BackupScript + '" > "' + TempResult + '"',
+         '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
+    if LoadStringFromFile(TempResult, JsonContent) then
+    begin
+      GlobalBackupMethod := ExtractJsonValue(JsonContent, 'method');
+      GlobalBackupPath := ExtractJsonValue(JsonContent, 'path');
+
+      if (GlobalBackupMethod <> '') and (GlobalBackupPath <> '') then
+      begin
+        RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'LastUpgradeTime', GetDateTimeString('yyyy-mm-dd hh:nn:ss', #0, #0));
+        RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'BackupMethod', GlobalBackupMethod);
+        RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'BackupPath', GlobalBackupPath);
+        RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'RollbackScript', ExpandConstant('{app}\bin\Rollback-To-Pre-Upgrade.bat'));
+
+        OldExe := ExpandConstant('{commonappdata}\Readarr\bin\Readarr.exe');
+        if FileExists(OldExe) then
+          if GetVersionNumbersString(OldExe, OldVer) then
+            RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'PreviousVersion', OldVer);
+      end;
+    end;
+  end;
+
+  // Existing behavior: stop + delete service (in-place upgrade needs fresh registration)
+  Exec('net', 'stop readarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Exec('sc', 'delete readarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode, Attempts: Integer;
+  IsRunning: Boolean;
+  RollbackScript: String;
+begin
+  if CurStep = ssPostInstall then
+  begin
+    // The [Run] /i entry registers + starts the service; verify it reached RUNNING
+    IsRunning := False;
+    Attempts := 0;
+    while (not IsRunning) and (Attempts < 30) do
+    begin
+      Sleep(2000);
+      Exec(ExpandConstant('{cmd}'),
+           '/c sc query Readarr | findstr /C:"RUNNING" > nul',
+           '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      IsRunning := (ResultCode = 0);
+      Attempts := Attempts + 1;
+    end;
+
+    if IsRunning then
+    begin
+      RegWriteStringValue(HKEY_LOCAL_MACHINE, REG_KEY, 'CurrentVersion', '{#BuildVersion}');
+    end
+    else if GlobalBackupPath <> '' then
+    begin
+      // Auto-rollback
+      RollbackScript := ExpandConstant('{tmp}\rollback.ps1');
+      Exec(ExpandConstant('{cmd}'),
+           '/c powershell -NoProfile -ExecutionPolicy Bypass -File "' + RollbackScript + '"',
+           '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode);
+      MsgBox('The new Readarr service did not reach RUNNING within 60 seconds.' + #13#10 +
+             'Your previous installation has been restored from backup:' + #13#10 + #13#10 +
+             GlobalBackupPath,
+             mbError, MB_OK);
+    end
+    else
+    begin
+      MsgBox('The new Readarr service did not start. No pre-upgrade backup was made ' +
+             '(fresh install). Check Event Viewer for details.',
+             mbError, MB_OK);
+    end;
+  end;
 end;

--- a/distribution/windows/setup/upgrade-helpers/do-backup.ps1
+++ b/distribution/windows/setup/upgrade-helpers/do-backup.ps1
@@ -1,0 +1,82 @@
+# Backs up Readarr before an in-place upgrade.
+# Tries the native Readarr API first (produces a user-restorable zip in Backups/).
+# Falls back to file-copy into C:\ProgramData\Readarr.backups\<timestamp>\ if API unreachable.
+# Emits JSON on stdout: {"method":"ApiZip|FileCopy","path":"<full path>"} — last line is the JSON.
+# Returns exit 0 always unless no backup was possible at all.
+
+$ErrorActionPreference = 'SilentlyContinue'
+$ProgressPreference = 'SilentlyContinue'
+
+$ReadarrRoot = 'C:\ProgramData\Readarr'
+$BackupRoot = 'C:\ProgramData\Readarr.backups'
+$ConfigFile = Join-Path $ReadarrRoot 'config.xml'
+
+function Emit-Result([string]$method, [string]$path) {
+    Write-Output (@{method = $method; path = $path} | ConvertTo-Json -Compress)
+}
+
+function Invoke-FileCopyBackup {
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $target = Join-Path $BackupRoot $timestamp
+    New-Item -ItemType Directory -Path $target -Force | Out-Null
+
+    $itemsToBackup = @('bin', 'config.xml',
+                       'readarr.db', 'readarr.db-journal', 'readarr.db-wal', 'readarr.db-shm',
+                       'Backups')
+    foreach ($item in $itemsToBackup) {
+        $src = Join-Path $ReadarrRoot $item
+        if (Test-Path $src) {
+            Copy-Item -Recurse -Force -Path $src -Destination $target -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Rotation: keep only 2 newest backup dirs
+    Get-ChildItem $BackupRoot -Directory -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -Skip 2 |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+    Emit-Result 'FileCopy' $target
+}
+
+# Try API-based backup
+try {
+    if (-not (Test-Path $ConfigFile)) { throw 'config.xml missing' }
+    $cfg = [xml](Get-Content $ConfigFile -Raw)
+    $port = $cfg.Config.Port
+    $apiKey = $cfg.Config.ApiKey
+    if (-not $port -or -not $apiKey) { throw 'port/apikey missing' }
+
+    $headers = @{'X-Api-Key' = $apiKey}
+    $body = @{name = 'Backup'} | ConvertTo-Json
+
+    $cmd = Invoke-RestMethod -Method POST `
+                              -Uri "http://localhost:$port/api/v1/command" `
+                              -Headers $headers -Body $body `
+                              -ContentType 'application/json' -TimeoutSec 10
+    $cmdId = $cmd.id
+
+    # Poll up to 5 min
+    $deadline = (Get-Date).AddMinutes(5)
+    do {
+        Start-Sleep -Seconds 2
+        $status = Invoke-RestMethod -Uri "http://localhost:$port/api/v1/command/$cmdId" `
+                                     -Headers $headers -TimeoutSec 10
+    } while ($status.status -notin @('completed','failed') -and (Get-Date) -lt $deadline)
+
+    if ($status.status -ne 'completed') { throw "command status: $($status.status)" }
+
+    # Locate the newest .zip under Backups/
+    $backupDir = Join-Path $ReadarrRoot 'Backups'
+    $newestZip = Get-ChildItem $backupDir -Filter '*.zip' -Recurse -ErrorAction SilentlyContinue |
+                  Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if (-not $newestZip) { throw 'no backup zip produced' }
+
+    Emit-Result 'ApiZip' $newestZip.FullName
+    exit 0
+}
+catch {
+    # Any failure → fall back to file copy
+    Invoke-FileCopyBackup
+    exit 0
+}

--- a/distribution/windows/setup/upgrade-helpers/rollback.ps1
+++ b/distribution/windows/setup/upgrade-helpers/rollback.ps1
@@ -1,0 +1,62 @@
+# Restores Readarr from a pre-upgrade backup recorded in the Windows Registry.
+# Reads HKLM\SOFTWARE\Readarr\Upgrade\{BackupMethod, BackupPath} to locate the backup.
+# Works for both ApiZip (native Readarr backup) and FileCopy (raw tree copy) methods.
+
+$ErrorActionPreference = 'Stop'
+
+$ReadarrRoot = 'C:\ProgramData\Readarr'
+$RegPath = 'HKLM:\SOFTWARE\Readarr\Upgrade'
+
+try {
+    $props = Get-ItemProperty -Path $RegPath
+    $method = $props.BackupMethod
+    $path = $props.BackupPath
+    if (-not $method -or -not $path) { throw 'missing registry values' }
+} catch {
+    Write-Host 'No upgrade record found in registry. Nothing to roll back.' -ForegroundColor Yellow
+    exit 1
+}
+
+if (-not (Test-Path $path)) {
+    Write-Host "Backup path not found on disk: $path" -ForegroundColor Red
+    Write-Host 'Cannot roll back.' -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Pre-upgrade backup: $path"
+Write-Host "Method: $method"
+Write-Host ''
+
+Write-Host 'Stopping Readarr service...'
+Stop-Service -Name Readarr -Force -ErrorAction SilentlyContinue
+$deadline = (Get-Date).AddSeconds(30)
+while ((Get-Service -Name Readarr -ErrorAction SilentlyContinue).Status -ne 'Stopped' -and (Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 1
+}
+
+Write-Host 'Restoring files...'
+if ($method -eq 'ApiZip') {
+    # Extract the Readarr-native zip over the install root
+    Expand-Archive -Path $path -DestinationPath $ReadarrRoot -Force
+}
+elseif ($method -eq 'FileCopy') {
+    # Copy backup dir contents back in place
+    Get-ChildItem -LiteralPath $path | ForEach-Object {
+        Copy-Item -Recurse -Force -Path $_.FullName -Destination $ReadarrRoot
+    }
+}
+else {
+    Write-Host "Unknown backup method: $method" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'Starting Readarr service...'
+Start-Service -Name Readarr -ErrorAction SilentlyContinue
+
+# Record rollback
+try {
+    Set-ItemProperty -Path $RegPath -Name LastRollbackTime -Value (Get-Date -Format 'o')
+} catch { }
+
+Write-Host ''
+Write-Host 'Rollback complete.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

When the Windows installer upgrades an existing Readarr install, it replaces binaries in-place with no safety net. If the new service fails to start — misconfigured file, DLL version mismatch, corrupt download, service-registration failure — the user is left on a broken install with no automatic recovery and no native backup.

This PR adds a backup-and-rollback layer that runs entirely inside the installer. No application code is touched; all additions live under `distribution/windows/setup/`.

## How it works

**Before any file is replaced:**
1. Try Readarr's own backup API (`POST /api/v1/command` with `name=Backup`). The resulting zip lands in `Backups/` alongside user-triggered backups and can be restored via Readarr's UI.
2. If the API path fails (service stopped, auth mismatch, timeout, version without API), fall back to a raw file-copy of the essentials (`bin/`, `config.xml`, `readarr.db*`, `Backups/`) into `C:\ProgramData\Readarr.backups\<YYYYMMDD-HHmmss>\`. Rotation keeps only the two most recent file-copy backups.
3. Record method, path, timestamp, and the previous `Readarr.exe` file version to `HKLM\SOFTWARE\Readarr\Upgrade\` so downstream tools can find the backup without depending on install-time paths.

**After install completes (`CurStepChanged ssPostInstall`):**
4. Poll `sc query Readarr` up to 60 seconds for `RUNNING`.
5. On success, record `CurrentVersion` in the registry.
6. On failure, invoke the rollback helper and surface the backup path via MsgBox. The user is left on a working pre-upgrade state.

**For later user-triggered rollback:**
7. `Rollback To Pre-Upgrade` Start Menu shortcut runs `rollback.ps1`, which reads the registry for the backup location/method, stops the service, restores files, and starts the service.

## Files

| File | What |
|---|---|
| `distribution/windows/setup/upgrade-helpers/do-backup.ps1` | API-first backup with file-copy fallback. Emits JSON `{method, path}` on stdout for the iss to capture. |
| `distribution/windows/setup/upgrade-helpers/rollback.ps1` | Reads registry, stops service, restores, starts service. |
| `distribution/windows/setup/Rollback-To-Pre-Upgrade.bat` | User entrypoint; confirms and invokes `rollback.ps1`. |
| `distribution/windows/setup/readarr.iss` | Extends `PrepareToInstall` (backup + registry), adds `CurStepChanged` (verify + auto-rollback), plus `[Files]` and `[Icons]` entries. |

## Test plan

- [x] Installer compiled successfully with ISCC against the extended iss
- [x] New installer includes all three helper files in the compressed setup data
- [ ] Fresh install on a machine with no prior Readarr → no backup taken, no registry entries written, install succeeds
- [ ] Upgrade on a machine with Readarr running → API-path backup produces a zip in `Backups/`, registry populated, service reaches RUNNING, CurrentVersion written
- [ ] Upgrade on a machine with Readarr stopped → falls back to file-copy backup, everything else same
- [ ] Deliberately-broken install (corrupt a shipped DLL mid-install) → service fails to reach RUNNING within 60s, auto-rollback fires, MsgBox shows backup path, pre-upgrade state restored
- [ ] User-triggered rollback via Start Menu → pre-upgrade state restored, service running

I'll be validating on a Windows Server 2022 host with an existing Readarr install; happy to report back or iterate on review feedback.

## Companion PR

The build step that compiles this iss fails without #152 (Inno Setup download URL is 404). These are independent in terms of files touched but testing this PR end-to-end requires #152 merged first (or a locally-patched `build.sh`).