### PR TITLE
Fix qBittorrent V2 auth check breaking against qBit 5.2.0+ (empty 204 response)

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -437,8 +437,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     throw new DownloadClientUnavailableException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
 
-                // returns "Fails." on bad login
-                if (response.Content != "Ok.")
+                // returns "Fails." on bad login; qBit 5.2.0+ returns empty 204 on success
+                if (response.Content.IsNotNullOrWhiteSpace() && response.Content != "Ok.")
                 {
                     _logger.Debug("qbitTorrent authentication failed.");
                     throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");


### PR DESCRIPTION
### Problem

qBittorrent 5.2.0 changed `POST /api/v2/auth/login` to return **HTTP 204 No Content** with an empty body on successful authentication. Before 5.2.0 the endpoint returned **HTTP 200** with body `"Ok."`.

The auth check in `QBittorrentProxyV2.AuthenticateClient` is:

```csharp
// returns "Fails." on bad login
if (response.Content != "Ok.")
{
    _logger.Debug("qbitTorrent authentication failed.");
    throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");
}
```

An empty 204 body is not `"Ok."`, so this throws `DownloadClientAuthenticationException` against any qBittorrent 5.2.0+ even when the login actually succeeded. The download client shows as **"Failed to authenticate with qBittorrent"** in Bookshelf and stops working.

The change is observable directly:

```
$ curl -i -X POST -d 'username=admin&password=...' http://qbit:8080/api/v2/auth/login
HTTP/1.1 204 No Content
Set-Cookie: SID=...; HttpOnly; SameSite=Strict
```

(Pre-5.2.0 the same call returned `HTTP/1.1 200 OK` and body `Ok.`.)

The qBit 5.2.0 release-notes line that documents this is **WEBAPI: Send 204 when WebAPI response contains no data** (qbittorrent/qBittorrent#21472, shipped in 5.2.0).

### Fix

Add a `IsNotNullOrWhiteSpace()` guard so an empty body short-circuits the failure branch — only treat the response as failed if it has content AND that content is not `"Ok."`:

```csharp
// returns "Fails." on bad login; qBit 5.2.0+ returns empty 204 on success
if (response.Content.IsNotNullOrWhiteSpace() && response.Content != "Ok.")
{
    _logger.Debug("qbitTorrent authentication failed.");
    throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");
}
```

`IsNotNullOrWhiteSpace()` is already in scope via the existing `using NzbDrone.Common.Extensions;` import — no new dependencies.

### Why this is the right shape

The same one-line guard already lives in **all the other Servarr forks** that share the qBit V2 proxy:

| Project | Status | File |
| --- | --- | --- |
| Sonarr | Has the guard | [`QBittorrentProxyV2.cs`](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs) |
| Radarr | Has the guard | (mirror of Sonarr) |
| Lidarr | Has the guard | (mirror of Sonarr) |
| Bookshelf | **Missing the guard** — this PR | — |

The behaviour difference is exactly why Sonarr/Radarr/Lidarr keep working against qBit 5.2.0 while Bookshelf does not. This change brings Bookshelf into line.

### Risk

Negligible. The guard only changes behaviour when `response.Content` is null or whitespace, which previously was always classified as "auth failed" and now is classified as "auth ok". Real failures still return either a non-2xx HTTP status (handled by the `catch (HttpException)` block above) or body `"Fails."` (still caught by the `!= "Ok."` half of the new condition).

### Test plan

- Connect Bookshelf to qBittorrent **5.1.x** (200 + `"Ok."`): auth still succeeds. ✅
- Connect Bookshelf to qBittorrent **5.2.0+** (204 + empty body): auth now succeeds. ✅ (was failing pre-patch)
- Connect Bookshelf with **wrong password** to either qBit version (200 + `"Fails."`): auth still throws `DownloadClientAuthenticationException`. ✅

Verified locally by rebuilding `Readarr.Core.dll` from a patched `develop` checkout (commit `c21c4134…`) and dropping it into the upstream `ghcr.io/pennydreadful/bookshelf:hardcover` image. Test Connection in Settings → Download Clients flips from red to green.