### PR TITLE
fix(AudioTag): null-safe Diff() for OriginalReleaseDate

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/AudioTag.cs
+++ b/src/NzbDrone.Core/MediaFiles/AudioTag.cs
@@ -477,10 +477,14 @@ namespace NzbDrone.Core.MediaFiles
 
             if (OriginalReleaseDate?.Date != other.OriginalReleaseDate?.Date)
             {
-                // Id3v2.3 tags can only store the year, not the full date
+                // Id3v2.3 tags can only store the year, not the full date.
+                // Apply the year-only shortcut only when both sides are present;
+                // otherwise fall through to the full-date else branch below which
+                // already handles a null on either side.
                 if (OriginalReleaseDate.HasValue &&
                     OriginalReleaseDate.Value.Month == 1 &&
-                    OriginalReleaseDate.Value.Day == 1)
+                    OriginalReleaseDate.Value.Day == 1 &&
+                    other.OriginalReleaseDate.HasValue)
                 {
                     if (OriginalReleaseDate.Value.Year != other.OriginalReleaseDate.Value.Year)
                     {


### PR DESCRIPTION
## Summary

`AudioTag.Diff()` throws `System.InvalidOperationException: Nullable object must have a value` when the file's `OriginalReleaseDate` is set but the metadata being compared against has it null (or vice versa). Three-line fix: only apply the year-only shortcut when both sides have a value.

## Context

Hit consistently after migrating an existing Readarr/Goodreads install to the `hardcover` image — Hardcover metadata commonly returns null release dates for works where Goodreads filled them in. Stack trace from a live failure:

```
[v0.4.20.129] System.InvalidOperationException: Nullable object must have a value.
   at NzbDrone.Core.MediaFiles.AudioTag.Diff(AudioTag other) in ./Readarr.Core/MediaFiles/AudioTag.cs:line 493
   at NzbDrone.Core.MediaFiles.AudioTagService.WriteTags(BookFile trackfile, Boolean newDownload, Boolean force) in ./Readarr.Core/MediaFiles/AudioTagService.cs:line 162
   at NzbDrone.Core.MediaFiles.BookImport.ImportApprovedBooks.Import(List`1 decisions, ...) in ./Readarr.Core/MediaFiles/BookImport/ImportApprovedBooks.cs:line 253
```

Downstream effect: `ImportApprovedBooks` bails on the file's import when the tag-write step throws, so no `BookFile` row gets written. In my install I saw the import scan run with `writeaudiotags=Sync` log a handful of explicit `Couldn't import book` warnings citing this stack trace, and ended with `BookFiles = 0` after metadata refresh + identification had completed for ~14k files. Setting `writeaudiotags=No` is the workaround that unblocked the import (BookFiles populated to ~13.9k cleanly); this PR is the proper fix.

## Root cause

The outer `?.Date != other.?.Date` check correctly passes when one side is null. The inner ID3v2.3 year-only shortcut then dereferences `other.OriginalReleaseDate.Value.Year` unconditionally, crashing when `other` is null.

The companion `Date` diff a few lines above is already null-safe (uses `HasValue` before `.Value`); this branch is just an oversight.

## Fix

```diff
                 // Id3v2.3 tags can only store the year, not the full date
                 if (OriginalReleaseDate.HasValue &&
                     OriginalReleaseDate.Value.Month == 1 &&
-                    OriginalReleaseDate.Value.Day == 1)
+                    OriginalReleaseDate.Value.Day == 1 &&
+                    other.OriginalReleaseDate.HasValue)
                 {
```

When `other` is null, fall through to the existing `else` branch which already handles `HasValue` on either side and emits a clean diff entry.

## Verification

- [x] Crash signature reproduced in my install on the current `hardcover-v0.4.20.129` image (logs above).
- [x] Code review: the fix matches the null-safety pattern already in use for the sibling `Date` diff a few lines above.
- [x] Built locally: `dotnet build NzbDrone.Core/Readarr.Core.csproj -c Release` clean — 0 warnings, 0 errors.
- [ ] CI to verify no regressions in the existing test suite.

No existing unit test covers `AudioTag.Diff()` in this repo (checked under `src/` for any `*AudioTag*Test*` files — none). Glad to add one if wanted; didn't want to scope-creep without a signal.