### PR TITLE
feat(QBittorrent): port API-key auth from Radarr/Sonarr

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -342,8 +342,17 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
             {
                 LogResponseContent = true,
-                NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password)
             };
+
+            if (settings.ApiKey.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.Headers["Authorization"] = $"Bearer {settings.ApiKey}";
+            }
+            else
+            {
+                requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
+            }
+
             return requestBuilder;
         }
 
@@ -357,6 +366,36 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         private string ProcessRequest(HttpRequestBuilder requestBuilder, QBittorrentSettings settings)
         {
+            // ApiKey-based auth (qBittorrent 5.x+): the Authorization header is
+            // already on requestBuilder via BuildRequest, so skip the cookie-auth
+            // flow entirely. Bad keys surface as HTTP 401/403 which we route to
+            // DownloadClientAuthenticationException.
+            if (settings.ApiKey.IsNotNullOrWhiteSpace())
+            {
+                var apiRequest = requestBuilder.Build();
+                apiRequest.LogResponseContent = true;
+
+                try
+                {
+                    return _httpClient.Execute(apiRequest).Content;
+                }
+                catch (HttpException ex)
+                {
+                    if (ex.Response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                    {
+                        _logger.Debug(ex, "qbitTorrent authentication failed.");
+                        throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);
+                    }
+
+                    throw new DownloadClientException("Failed to connect to qBittorrent, check your settings.", ex);
+                }
+                catch (WebException ex)
+                {
+                    throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
+                }
+            }
+
+            // Legacy username/password cookie-auth flow.
             AuthenticateClient(requestBuilder, settings);
 
             var request = requestBuilder.Build();

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -14,6 +14,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
             RuleFor(c => c.UrlBase).ValidUrlBase().When(c => c.UrlBase.IsNotNullOrWhiteSpace());
 
+            RuleFor(c => c.Username).Empty()
+                .WithMessage("Username must be empty when using API Key.")
+                .When(c => c.ApiKey.IsNotNullOrWhiteSpace());
+            RuleFor(c => c.Password).Empty()
+                .WithMessage("Password must be empty when using API Key.")
+                .When(c => c.ApiKey.IsNotNullOrWhiteSpace());
+
             RuleFor(c => c.MusicCategory).Matches(@"^([^\\\/](\/?[^\\\/])*)?$").WithMessage(@"Can not contain '\', '//', or start/end with '/'");
             RuleFor(c => c.MusicImportedCategory).Matches(@"^([^\\\/](\/?[^\\\/])*)?$").WithMessage(@"Can not contain '\', '//', or start/end with '/'");
         }
@@ -42,34 +49,37 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(3, Label = "Url Base", Type = FieldType.Textbox, Advanced = true, HelpText = "Adds a prefix to the qBittorrent url, e.g. http://[host]:[port]/[urlBase]/api")]
         public string UrlBase { get; set; }
 
-        [FieldDefinition(4, Label = "Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(4, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "Use an API key instead of username/password (qBittorrent 5.x+). Leave username and password empty when using this.")]
+        public string ApiKey { get; set; }
+
+        [FieldDefinition(5, Label = "Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(5, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(6, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(6, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Readarr avoids conflicts with unrelated non-Readarr downloads. Using a category is optional, but strongly recommended.")]
+        [FieldDefinition(7, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Readarr avoids conflicts with unrelated non-Readarr downloads. Using a category is optional, but strongly recommended.")]
         public string MusicCategory { get; set; }
 
-        [FieldDefinition(7, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Readarr to set after it has imported the download. Readarr will not remove the torrent if seeding has finished. Leave blank to keep same category.")]
+        [FieldDefinition(8, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Readarr to set after it has imported the download. Readarr will not remove the torrent if seeding has finished. Leave blank to keep same category.")]
         public string MusicImportedCategory { get; set; }
 
-        [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing books released within the last 14 days")]
+        [FieldDefinition(9, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing books released within the last 14 days")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing books released over 14 days ago")]
+        [FieldDefinition(10, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing books released over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent. Note that Forced Torrents do not abide by seed restrictions")]
+        [FieldDefinition(11, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent. Note that Forced Torrents do not abide by seed restrictions")]
         public int InitialState { get; set; }
 
-        [FieldDefinition(11, Label = "Sequential Order", Type = FieldType.Checkbox, HelpText = "Download in sequential order (qBittorrent 4.1.0+)")]
+        [FieldDefinition(12, Label = "Sequential Order", Type = FieldType.Checkbox, HelpText = "Download in sequential order (qBittorrent 4.1.0+)")]
         public bool SequentialOrder { get; set; }
 
-        [FieldDefinition(12, Label = "First and Last First", Type = FieldType.Checkbox, HelpText = "Download first and last pieces first (qBittorrent 4.1.0+)")]
+        [FieldDefinition(13, Label = "First and Last First", Type = FieldType.Checkbox, HelpText = "Download first and last pieces first (qBittorrent 4.1.0+)")]
         public bool FirstAndLast { get; set; }
 
-        [FieldDefinition(13, Label = "DownloadClientQbittorrentSettingsContentLayout", Type = FieldType.Select, SelectOptions = typeof(QBittorrentContentLayout), HelpText = "DownloadClientQbittorrentSettingsContentLayoutHelpText")]
+        [FieldDefinition(14, Label = "DownloadClientQbittorrentSettingsContentLayout", Type = FieldType.Select, SelectOptions = typeof(QBittorrentContentLayout), HelpText = "DownloadClientQbittorrentSettingsContentLayoutHelpText")]
         public int ContentLayout { get; set; }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
## Summary

Port qBittorrent's API-key authentication support (introduced in qBittorrent 5.x) from Radarr and Sonarr to bookshelf. Adds an `ApiKey` field to the qBit download-client settings; when populated, requests carry an `Authorization: Bearer <key>` header and the cookie-auth flow is bypassed entirely.

Existing username/password configurations see no behavior change.

## Why

qBittorrent 5.x added API tokens as a more secure / scriptable alternative to user passwords. Radarr ([source](https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs)) and Sonarr both support it; bookshelf is the odd one out among the *arrs. Users running modern qBit who'd prefer API-key auth currently can't.

## Changes

**`QBittorrentSettings.cs`**
- New `ApiKey` field at `FieldDefinition(4)`, with `PrivacyLevel.ApiKey` so it's masked in the UI and exported configs.
- Validator rejects configurations where `ApiKey` is set alongside `Username` or `Password`, mirroring Radarr's rule.
- Renumber existing `FieldDefinition` order numbers (5..14) to slot the API Key field right above Username/Password where users naturally look for it. Property names are unchanged — stored configs are unaffected.

**`QBittorrentProxyV2.cs`**
- `BuildRequest` emits `Authorization: Bearer <key>` when `ApiKey` is set and only attaches `BasicNetworkCredential` when falling back to username/password.
- `ProcessRequest` gains a fast path for the `ApiKey` case that skips `AuthenticateClient` (no cookie session needed) and routes 401/403 directly to `DownloadClientAuthenticationException`, matching the Radarr/Sonarr pattern.

## Independent of #162

This PR is intentionally orthogonal to https://github.com/pennydreadful/bookshelf/pull/162 (the auth-response-handling fix). It builds and works whether or not #162 has landed:

- `ApiKey` users follow a fast path that doesn't touch the `Content != "Ok."` check at all.
- Username/password users on this branch alone hit the unchanged legacy code path, which still has the empty-body bug #162 fixes. Once both PRs land they're additive.

## Test plan

- [x] Cross-checked the patch against Radarr's and Sonarr's `QBittorrentSettings.cs` + `QBittorrentProxyV2.cs` for behavioral parity.
- [x] Stored configs preserved (`FieldDefinition` numbers are display-order only; property names are unchanged).
- [x] Built locally: `dotnet build NzbDrone.Core/Readarr.Core.csproj -c Release` clean — 0 warnings, 0 errors.
- [ ] CI to verify build + existing tests.

## Out of scope

Other divergences between bookshelf's and Radarr/Sonarr's qBit clients (the `AddTags()` method, base-class refactor to `DownloadClientSettingsBase`, translation-key labels, etc.) are deliberately not part of this PR — kept tight to the API-key feature so it's easy to review and accept.