### PR TITLE
Fix qBittorrent 5.2.0 authentication failure (HTTP 204 on login)

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -437,8 +437,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     throw new DownloadClientUnavailableException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
 
-                // returns "Fails." on bad login
-                if (response.Content != "Ok.")
+                // returns "Fails." on bad login. qBittorrent 5.2.0+ returns 204 with an empty body on success.
+                if (response.Content.IsNotNullOrWhiteSpace() && response.Content != "Ok.")
                 {
                     _logger.Debug("qbitTorrent authentication failed.");
                     throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");


### PR DESCRIPTION
qBittorrent 5.2.0 changed `/api/v2/auth/login` to return `204 No Content` with an empty body on successful login, instead of `200` with `Ok.`. The auth check in `QBittorrentProxyV2` treats anything that isn't `Ok.` as a failure, so valid credentials are rejected with "Authentication failure" even though qBittorrent logs the login as successful.

This migrates the same one-line fix Sonarr and Radarr already applied for this change: treat an empty response body as success. Bad logins are unaffected — they still return a non-empty `Fails.` body (older versions) or a 401/403 (5.2.0), both of which are still rejected.

Tested against qBittorrent 5.2.0: download client test and add now succeed.

Fixes #160